### PR TITLE
Fixed issue 36 on contact.html template

### DIFF
--- a/AlertaDengue/dados/templates/contact.html
+++ b/AlertaDengue/dados/templates/contact.html
@@ -9,25 +9,25 @@
         </div>
         <div class="panel-body">
             O Sistema de Alerta Info Dengue é desenvolvido graças a parceria entre pesquisadores de diversas instituições e o serviço público:<br><br>
-            <b>Coordenação Geral</b>
-            Flávio Codeço Coelho: Professor Associado - Escola de Matemática Aplicada/FGV
-            Oswaldo Gonçalves Cruz: Pesquisador Titular - Programa de Computação Científica/Fiocruz
+            <b>Coordenação Geral</b><br>
+            Flávio Codeço Coelho: Professor Associado - Escola de Matemática Aplicada/FGV<br>
+            Oswaldo Gonçalves Cruz: Pesquisador Titular - Programa de Computação Científica/Fiocruz<br>
             Cláudia Torres Codeço: Pesquisadora Titular - Programa de Computação Científica/Fiocruz<br><br>
-            <b>Gestão do Projeto</b>
+            <b>Gestão do Projeto</b><br>
             Thais Riback: Pesquisadora Colaboradora - Programa de Computação Científica/Fiocruz<br><br>
-            <b>Desenvolvimento</b>
-            Israel Teixeira: Desenvolvedor - InfoDengue
+            <b>Desenvolvimento</b><br>
+            Israel Teixeira: Desenvolvedor - InfoDengue<br>
             Marcelo Gomes: Pesquisador Visitante - Programa de Computação Científica/Fiocruz<br><br>
-            <b>Colaboradores</b>
-            Wagner Meira: Professor Titular – Departamento de Ciência da Computação/UFMG 
-            Walter dos Santos Filho: Observatório da Dengue/UFMG 
-            Magda Clara Vieira da Costa Ribeiro: Professora Adjunta – Instituto de Biociências/UFPR 
-            Jean Carlos dos Santos Barrado: Doutorando – ENSP/Fiocruz 
-            Cláudia Brandelero Rizzi: Professora - Curso de Ciência da Computação/UNIOESTE
+            <b>Colaboradores</b><br>
+            Wagner Meira: Professor Titular – Departamento de Ciência da Computação/UFMG<br>
+            Walter dos Santos Filho: Observatório da Dengue/UFMG<br>
+            Magda Clara Vieira da Costa Ribeiro: Professora Adjunta – Instituto de Biociências/UFPR<br>
+            Jean Carlos dos Santos Barrado: Doutorando – ENSP/Fiocruz<br>
+            Cláudia Brandelero Rizzi: Professora - Curso de Ciência da Computação/UNIOESTE<br>
             Carolin Degener: Pós-Doutoranda – Programa de Computação Científica/Fiocruz<br><br>
-            <b>Apoio</b>
-            <a href="http://observatorio.inweb.org.br/">Observatório da Dengue</a>
-            <a href="http://www.rio.rj.gov.br/web/sms">Secretaria Municipal de Saúde/Rio de Janeiro/RJ</a>
+            <b>Apoio</b><br>
+            <a href="http://observatorio.inweb.org.br/">Observatório da Dengue</a><br>
+            <a href="http://www.rio.rj.gov.br/web/sms">Secretaria Municipal de Saúde/Rio de Janeiro/RJ</a><br>
             
             <p>Gostaria de ter mais informações ou tirar dúvidas sobre o Sistema de Alerta Info Dengue? 
             Entre em contato conosco: <a href="mailto:alerta_dengue@fiocruz.br"</a>


### PR DESCRIPTION
Included line breaks after topics and contributors.
Issue #36 