### PR TITLE
Fixes bug in DBF import when dt_nasc is None

### DIFF
--- a/AlertaDengue/dbf/sinan.py
+++ b/AlertaDengue/dbf/sinan.py
@@ -155,8 +155,7 @@ class Sinan(object):
                 row[7] = None if not row[7] else int(row[7])  # bairro_bairro_id
                 row[8] = None if row[8] == '' else add_dv(int(row[8]))  # municipio_geocodigo
                 row[9] = int(row[9])  # nu_notific
-                row[11] = None if isinstance(row[11], pd.tslib.NaTType) else date.fromordinal(
-                    row[11].to_datetime().toordinal())  # dt_nasc
+                row[11] = None if (isinstance(row[11], pd.tslib.NaTType) or row[11] is None) else date.fromordinal(row[11].to_datetime().toordinal())  # dt_nasc
                 row[13] = None if not row[13] else int(row[13])  # nu_idade_n
                 cursor.execute(insert_sql, row)
                 if (i % 1000 == 0) and (i > 0):


### PR DESCRIPTION
@fccoelho você pode revisar por favor?

Isso corrige o "AttributeError: 'NoneType' object has no attribute 'to_datetime'" quando tentávamos importar alguns DBFs.

Uma coisa a se prestar atenção é que quando eu importei um DBF que caía nesse erro, o número de casos no banco aumentou. Acho que foi por que esse DBF não tinha sido de fato importado (já que esbarrava nesse bug), mas queria saber sua opinião sobre isso.

Isso não resolve o bug descrito em #138 , pra isso precisamos saber o que fazer nos casos em que o CID não estiver descrito no DBF (não só para os casos do Paraná, mas em todos os casos).