### PR TITLE
Remove dbf date restriction

### DIFF
--- a/AlertaDengue/dbf/sinan.py
+++ b/AlertaDengue/dbf/sinan.py
@@ -86,12 +86,6 @@ class Sinan(object):
             self.tabela["ID_MUNICIP"] = self.tabela.ID_MN_RESI
             del self.tabela['ID_MN_RESI']
         self._parse_date_cols()
-        if not (self.time_span[0].year == self.ano and self.time_span[1].year == self.ano):
-            raise ValidationError(_("Existem nesse arquivo notificações "
-                "incompatíveis com o ano de notificação informado. "
-                "Por favor, tenha certeza de que o ano de notificação é o mesmo "
-                "para todos os registros no arquivo e de que este foi o ano "
-                "informado no momento do envio."))
 
     def _parse_date_cols(self):
         print("Formatando as datas...")

--- a/AlertaDengue/dbf/tasks.py
+++ b/AlertaDengue/dbf/tasks.py
@@ -12,32 +12,40 @@ import shutil
 
 
 def send_success_email(dbf):
-    subject = "[InfoDengue] DBF enviado em {:%d/%m/%Y} importado com successo".format(
-            dbf.uploaded_at)
+    subject = ("[InfoDengue] DBF enviado em {:%d/%m/%Y} "
+               "importado com successo".format(dbf.uploaded_at))
     body = render_to_string("successful_import_email.txt",
-            context={"dbf": dbf})
+                            context={"dbf": dbf})
 
     message_data = (
-        (subject, body, settings.EMAIL_FROM_ADDRESS, [dbf.uploaded_by.email]),
-        (subject, body, settings.EMAIL_FROM_ADDRESS, [settings.INFODENGUE_TEAM_EMAIL])
+        (subject, body, settings.EMAIL_FROM_ADDRESS,
+         [dbf.uploaded_by.email]),
+        (subject, body, settings.EMAIL_FROM_ADDRESS,
+         [settings.INFODENGUE_TEAM_EMAIL])
     )
     send_mass_mail(message_data)
 
+
 def send_failure_email(dbf, message):
-    subject = "[InfoDengue] Falha ao importar DBF enviado em {:%d/%m/%Y}".format(
-            dbf.uploaded_at)
+    subject = ("[InfoDengue] Falha ao importar DBF enviado em "
+               "{:%d/%m/%Y}".format(dbf.uploaded_at))
     body = render_to_string("failed_import_email.txt",
-            context={"dbf": dbf, "error_message": message})
+                            context={"dbf": dbf, "error_message": message})
 
     message_data = (
-        (subject, body, settings.EMAIL_FROM_ADDRESS, [dbf.uploaded_by.email]),
-        (subject, body, settings.EMAIL_FROM_ADDRESS, [settings.INFODENGUE_TEAM_EMAIL])
+        (subject, body, settings.EMAIL_FROM_ADDRESS,
+         [dbf.uploaded_by.email]),
+        (subject, body, settings.EMAIL_FROM_ADDRESS,
+         [settings.INFODENGUE_TEAM_EMAIL])
     )
     send_mass_mail(message_data)
 
 
 def copy_file_to_final_destination(dbf):
-    new_filename = "{}_{}_{}_{}.dbf".format(dbf.state_abbreviation, dbf.municipio, dbf.export_date, dbf.notification_year)
+    new_filename = "{}_{}_{}_{}.dbf".format(dbf.state_abbreviation,
+                                            dbf.municipio,
+                                            dbf.export_date,
+                                            dbf.notification_year)
     src = dbf.file.path
     dest = os.path.join(settings.IMPORTED_FILES_DIR, new_filename)
     shutil.copy(src, dest)


### PR DESCRIPTION
@fccoelho você pode por favor revisar esse Pull Request?

Não fiz muitas mudanças. Só removi mesmo a validação de que só existem notificações de um ano no arquivo.

Existe um caso em que notificações de um ano anterior poderiam acabar sendo tratadas como notificações do ano informado na hora do upload (na [linha 142](https://github.com/AlertaDengue/AlertaDengue/compare/master...flavioamieiro:remove_dbf_date_restriction?expand=1#diff-80296f2d01b32acb467c4f146ea125b5R142) do sinan.py), mas esse caso já não seria pego pela validação (ele só deveria cair nesse caso se a notificação não tiver a data, ou seja, não temos como evitar essa possibilidade).

@sarasouzabh tentei também encontrar o motivo para o e-mail de erro não ter sido enviado, mas não consegui reproduzir esse comportamento no meu ambiente de testes. Todas as vezes em que um erro de validação foi encontrado o e-mail de erro foi enviado. Vou tentar descobrir se o problema não está na configuração do servidor (e por algum motivo os e-mails de sucesso chegam mas os de erro não).