### PR TITLE
Start fixing auto redirect of alerta/3304557/dengue to alerta/rio/dengue

### DIFF
--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -32,7 +32,7 @@ db_engine = create_engine(PSQL_URI)
 con = ibis.postgres.connect(url=PSQL_URI)
 
 # rio de janeiro city geocode
-MRJ_GEOCODE = 3304557
+MRJ_GEOCODE = 3304557 #TODO chop it out!
 
 CID10 = {"dengue": "A90", "chikungunya": "A92.0", "zika": "A928"}
 DISEASES_SHORT = ["dengue", "chik", "zika"]
@@ -442,7 +442,7 @@ def get_all_active_cities() -> List[Tuple[str, str]]:
             )
     return res
 
-
+#TODO chop it out!
 def get_alerta_mrj():
     """
     Fetch the alert table for the city of Rio de janeiro
@@ -452,7 +452,7 @@ def get_alerta_mrj():
     with db_engine.connect() as conn:
         return pd.read_sql_query(sql, conn, index_col="id")
 
-
+#TODO chop it out!
 def get_alerta_mrj_chik():
     """
     Fetch the alert table for the city of Rio de janeiro
@@ -462,7 +462,7 @@ def get_alerta_mrj_chik():
     with db_engine.connect() as conexao:
         return pd.read_sql_query(sql, conexao, index_col="id")
 
-
+#TODO chop it out!
 def get_alerta_mrj_zika():
     """
     Fetch the alert table for the city of Rio de janeiro
@@ -594,42 +594,19 @@ def load_cases_without_forecast(geocode: int, disease):
     :return:
     """
     with db_engine.connect() as conn:
-        if geocode == MRJ_GEOCODE:  # RJ city
-            table_name = "alerta" + get_disease_suffix(disease)
+        
+        table_name = "Historico_alerta" + get_disease_suffix(disease)
 
-            data_alert = pd.read_sql_query(
-                """
-                SELECT
-                   data AS "data_iniSE",
-                   SUM(casos_estmin) AS casos_est_min,
-                   SUM(casos_est) as casos_est,
-                   SUM(casos_estmax) AS casos_est_max,
-                   SUM(casos) AS casos,
-                   MAX(nivel) AS nivel,
-                   se AS "SE",
-                   SUM(prt1) AS p_rt1
-                 FROM "Municipio".{}
-                 GROUP BY "data_iniSE", "SE"
-                """.format(
-                    table_name
-                ),
-                conn,
-                parse_dates=True,
-            )
-
-        else:
-            table_name = "Historico_alerta" + get_disease_suffix(disease)
-
-            data_alert = pd.read_sql_query(
-                """
-                SELECT * FROM "Municipio"."{}"
-                WHERE municipio_geocodigo={} ORDER BY "data_iniSE" ASC
-                """.format(
-                    table_name, geocode
-                ),
-                conn,
-                parse_dates=True,
-            )
+        data_alert = pd.read_sql_query(
+            """
+            SELECT * FROM "Municipio"."{}"
+            WHERE municipio_geocodigo={} ORDER BY "data_iniSE" ASC
+            """.format(
+                table_name, geocode
+            ),
+            conn,
+            parse_dates=True,
+        )
     return data_alert
 
 

--- a/AlertaDengue/dados/templates/alert_base.html
+++ b/AlertaDengue/dados/templates/alert_base.html
@@ -440,11 +440,8 @@
     <br>
 <div class="card-footer">
     <h4 id="section1" class="panel-title"><b>{% trans "Relatório da Situação das Arboviroses em" %}: </b>
-    {% if geocode == "3304557" %}
-        <a href="{% url 'dados:report_city' state=state_abv geocode=geocode year_week=yearweek %}"> {{ nome }} </a></h4>
-    {% else %}
-        <a href="{% url 'dados:report_city' state=state_abv geocode=geocode year_week=SE %}"> {{ nome }} </a></h4>
-    {% endif %}
+
+      <a href="{% url 'dados:report_city' state=state_abv geocode=geocode year_week=SE %}"> {{ nome }} </a></h4>
 
     <h4 id="section1" class="panel-title"><b>{% trans "Para mais detalhes, acesse a página de Estados" %}:</b>
     <a href="{% url 'dados:alerta_uf' disease=disease_code state=state_abv %}">{{state}}</a></h4>

--- a/AlertaDengue/dados/urls.py
+++ b/AlertaDengue/dados/urls.py
@@ -7,9 +7,8 @@ from django.views.generic import TemplateView
 # local
 from .views import (
     AboutPageView,
-    AlertaGeoJSONView,
+    AlertaGeoJSONView, #TODO chop it out!
     AlertaMainView,
-    AlertaMRJPageView,
     AlertaMunicipioPageView,
     AlertaStateView,
     ChartsMainView,
@@ -29,10 +28,6 @@ from .views import (
 
 def redirect_alerta_dengue(request, state):
     return redirect("dados:alerta_uf", state=state, disease="dengue")
-
-
-def redirect_alert_rio_dengue(request):
-    return redirect("dados:mrj", disease="dengue")
 
 
 def redirect_alert_city_dengue(request, geocodigo):
@@ -117,13 +112,9 @@ urlpatterns = [
         AlertaStateView.as_view(),
         name="alerta_uf",
     ),
-    re_path(r"^alerta/rio/$", redirect_alert_rio_dengue),
+    re_path(r"^alert-city/%s[/]?$" % __geocode, redirect_alert_city_dengue),
     re_path(
-        r"^alerta/rio/%s$" % __disease, AlertaMRJPageView.as_view(), name="mrj"
-    ),
-    re_path(r"^alerta/%s[/]?$" % __geocode, redirect_alert_city_dengue),
-    re_path(
-        r"^alerta/%s/%s$" % (__geocode, __disease),
+        r"^alert-city/%s/%s$" % (__geocode, __disease),
         AlertaMunicipioPageView.as_view(),
         name="alerta_cidade",
     ),


### PR DESCRIPTION
fix #541 

I was able to access the most updated database via Rio de Janeiro Geocode in .../alert-city/3304557/dengue, but it was a palliative solution, because if you try to change the URL back to `alerta`, it breaks again.

A lot of legacy code involving RJ geocode is still in the project, and needs a careful look to decouple the hard-coded mrj.