### PR TITLE
Download file instead of opening the data in a new tab

### DIFF
--- a/AlertaDengue/api/views.py
+++ b/AlertaDengue/api/views.py
@@ -185,8 +185,10 @@ class AlertCityView(View, _GetMethod):
                 result = "[EE] error_message: %s" % e
 
         content_type = "application/json" if format == "json" else "text/plain"
+        response = HttpResponse(result, content_type=content_type)
+        response['Content-Disposition'] = f'attachment; filename="{disease.upper()}{geocode}_{ew_start}-{ew_end}.{format}"'
 
-        return HttpResponse(result, content_type=content_type)
+        return response
 
 
 class EpiYearWeekView(View, _GetMethod):

--- a/AlertaDengue/api/views.py
+++ b/AlertaDengue/api/views.py
@@ -186,7 +186,9 @@ class AlertCityView(View, _GetMethod):
 
         content_type = "application/json" if format == "json" else "text/plain"
         response = HttpResponse(result, content_type=content_type)
-        response['Content-Disposition'] = f'attachment; filename="{disease.upper()}{geocode}_{ew_start}-{ew_end}.{format}"'
+        response[
+            "Content-Disposition"
+        ] = f'attachment; filename="{disease}_{ew_start}-{ew_end}.{format}"'
 
         return response
 


### PR DESCRIPTION
fix #449


simply added an `attachment;` clause into the API response. 