### PR TITLE
feat: Fix error in sync_geofiles command

### DIFF
--- a/AlertaDengue/gis/management/commands/sync_geofiles.py
+++ b/AlertaDengue/gis/management/commands/sync_geofiles.py
@@ -106,11 +106,15 @@ class Command(BaseCommand):
 
             shp_min = multipolygon.simplify(0.005)
             with open(geojson_simplified_path, "w") as f:
+                properties = shp[0]["properties"]
+                properties_serializable = {
+                    key: str(value) for key, value in properties.items()
+                }
                 geojson_geometry = shapely.geometry.mapping(shp_min)
                 geojson_content = {
                     "type": "Feature",
                     "id": str(geocode),
-                    "properties": shp[0]["properties"],
+                    "properties": properties_serializable,
                     "geometry": geojson_geometry,
                 }
                 json.dump(geojson_content, f)


### PR DESCRIPTION
This pull request addresses the error that occurs when running the "sync_geofiles" command, preventing the successful synchronization of GeoJSON files and related operations. The issue was caused by a serialization error when dumping the GeoJSON content into a file.

Closes #646