### PR TITLE
feat: Introduce Django cache management and memcached service expose port

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -63,6 +63,8 @@ groups:
   develop:
     env-file: .env
     help: Development tasks and utilities.
+    vars:
+      manage_py: python AlertaDengue/manage.py
     targets:
       # CI
       container-wait:
@@ -87,6 +89,8 @@ groups:
       clean:
         help: Clean all generated artifacts from the project.
         shell: python
+        dependencies:
+          - target: develop.clear_cache
         args:
           path:
             help: Specify the path of the files to remove.
@@ -111,3 +115,13 @@ groups:
                       shutil.rmtree(file)
                   else:
                       file.unlink()
+
+      clear_cache:
+        help: Clear all Django cache
+        args:
+          subcommand:
+            help: Specify a Django subcommand to run.
+            type: string
+            default: clearcache
+        run: |
+          {{ vars.manage_py }} {{ args.subcommand }}

--- a/AlertaDengue/dados/management/commands/clearcache.py
+++ b/AlertaDengue/dados/management/commands/clearcache.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.core.cache import caches
+
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    help = "Clear cache"
+
+    def handle(self, **options):
+        for k in settings.CACHES.keys():
+            caches[k].clear()
+            self.stdout.write("Cleared cache '{}'.\n".format(k))

--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -8,6 +8,11 @@ services:
     entrypoint:
       - memcached
       - -m 64
+    ports:
+      - ${MEMCACHED_PORT}:11211
+    expose:
+      - ${MEMCACHED_PORT}
+
     healthcheck:
       test: ["CMD", "nc", "-z", "localhost", "11211"]
       interval: 10s


### PR DESCRIPTION
This pull request introduces two key enhancements:

- Added a custom Django management command, 'clearcache,' to conveniently clear the cache for all configured cache backends in a Django project.

- Exposed the port for the Memcached service in the Docker Compose YAML.

- Closes: #687
