### PR TITLE
feat(containers): Fix pgBackRest repository ownership in sidecar

### DIFF
--- a/containers/compose-pgbackrest.yaml
+++ b/containers/compose-pgbackrest.yaml
@@ -8,6 +8,7 @@ services:
   pgbackrest:
     hostname: pgbackrest
     restart: unless-stopped
+    user: "${HOST_UID}:${HOST_GID}"
     build:
       context: ..
       dockerfile: containers/pgbackrest/Dockerfile

--- a/containers/compose-staging.yaml
+++ b/containers/compose-staging.yaml
@@ -14,8 +14,6 @@ services:
       - "unix_socket_directories=/var/run/postgresql"
       - -c
       - "max_worker_processes=8"
-      - -c
-      - "archive_mode=off"
 
   web:
     command: bash /opt/runwsgi.sh

--- a/containers/pgbackrest/Dockerfile
+++ b/containers/pgbackrest/Dockerfile
@@ -1,5 +1,8 @@
 FROM postgres:14-bullseye
 
+ARG HOST_UID
+ARG HOST_GID
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     pgbackrest \
@@ -7,11 +10,24 @@ RUN apt-get update \
     bash \
   && rm -rf /var/lib/apt/lists/*
 
+RUN usermod -u ${HOST_UID} postgres \
+  && groupmod -g ${HOST_GID} postgres \
+  && chown -R ${HOST_UID}:${HOST_GID} \
+    /var/lib/postgresql \
+    /var/run/postgresql
+
 RUN mkdir -p \
     /etc/pgbackrest \
     /var/lib/pgbackrest \
     /var/lib/pgbackrest/spool \
     /var/log/pgbackrest \
+    /var/run/postgresql \
+  && chown -R ${HOST_UID}:${HOST_GID} \
+    /etc/pgbackrest \
+    /var/lib/pgbackrest \
+    /var/log/pgbackrest \
     /var/run/postgresql
+
+USER postgres
 
 CMD ["bash", "-lc", "sleep infinity"]

--- a/docs/pgbackrest/postgresql-backup-restore.md
+++ b/docs/pgbackrest/postgresql-backup-restore.md
@@ -257,6 +257,27 @@ docker exec infodengue-dev-postgres-1 \
   su - postgres -c "pgbackrest --stanza=dev check"
 ```
 
+If logs show `Permission denied` for files such as
+`/var/lib/pgbackrest/archive/prod/archive.info` or `backup.info`, verify that
+the repository is owned by the PostgreSQL runtime user:
+
+```bash
+docker exec infodengue-prod-postgres-1 \
+  find /var/lib/pgbackrest ! -user postgres -o ! -group postgres
+```
+
+The pgBackRest sidecar must run as the same `HOST_UID:HOST_GID` used by the
+postgres container. If an older root-run sidecar already created repository
+files, stop backup activity and repair ownership once:
+
+```bash
+docker exec -u root infodengue-prod-postgres-1 \
+  chown -R postgres:postgres /var/lib/pgbackrest /var/log/pgbackrest
+
+docker exec infodengue-prod-postgres-1 \
+  su - postgres -c "pgbackrest --stanza=prod check"
+```
+
 ### Backup Repository Empty / "no valid backups"
 
 ```bash


### PR DESCRIPTION
### Description:
This PR aligns the pgBackRest sidecar with the PostgreSQL container runtime user by remapping postgres to HOST_UID:HOST_GID, owning pgBackRest writable paths accordingly,  and running the service with that same UID/GID. It also documents how to diagnose and repair existing root-owned pgBackRest repository files that can break WAL archiving with archive.info  or backup.info permission errors.
- Closes #936.