### PR TITLE
fix(docker): remove public memcached port exposure

### DIFF
--- a/containers/compose-base.yaml
+++ b/containers/compose-base.yaml
@@ -1,12 +1,12 @@
 services:
   memcached:
     image: memcached:alpine
-    entrypoint:
+    command:
       - memcached
       - -m
       - "64"
-    ports:
-      - "${MEMCACHED_PORT}:11211"
+      - -U
+      - "0"
     expose:
       - "11211"
     healthcheck:


### PR DESCRIPTION
#### Description:
 Remove the external port publication and keep Memcached accessible only through the internal Docker network to reduce the attack surface and prevent further security notifications.
 - Closes #946 