### PR TITLE
fix(report-city): correct city report chart and table rendering

### DIFF
--- a/AlertaDengue/dados/charts/cities.py
+++ b/AlertaDengue/dados/charts/cities.py
@@ -235,6 +235,9 @@ class ReportCityCharts:
         if not varcli_keys:
             return ""
 
+        def get_series_label(index: int) -> str:
+            return str(varcli_values[index][0])
+
         df_climate = deepcopy(df[["SE", *varcli_keys]])
         for column in varcli_keys:
             df_climate[column] = pd.to_numeric(
@@ -255,16 +258,16 @@ class ReportCityCharts:
             go.Scatter(
                 x=df_climate["SE"],
                 y=df_climate[varcli_keys[0]],
-                name=f"{varcli_keys[0]}",
+                name=get_series_label(0),
                 mode="lines",
                 line={"color": "rgb(255, 204, 153)", "width": 3},
                 customdata=df_climate[varcli_keys[1]]
                 if len(varcli_keys) == 2
                 else [None] * len(df_climate),
                 hovertemplate="SE: %{x}<br>"
-                + f"<b>{varcli_keys[0]}</b>: %{{y:.1f}}<br>"
+                + f"<b>{get_series_label(0)}</b>: %{{y:.1f}}<br>"
                 + (
-                    f"<b>{varcli_keys[1]}</b>: %{{customdata:.1f}}"
+                    f"<b>{get_series_label(1)}</b>: %{{customdata:.1f}}"
                     if len(varcli_keys) == 2
                     else ""
                 )
@@ -300,7 +303,7 @@ class ReportCityCharts:
                 go.Scatter(
                     x=df_climate["SE"],
                     y=df_climate[varcli_keys[1]],
-                    name=f"{varcli_keys[1]}",
+                    name=get_series_label(1),
                     mode="lines",
                     line={"color": "rgb(173, 216, 230)", "width": 3},
                     hoverinfo="skip",

--- a/AlertaDengue/dados/charts/cities.py
+++ b/AlertaDengue/dados/charts/cities.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any
 
 import pandas as pd
 import plotly.graph_objs as go
@@ -220,8 +221,8 @@ class ReportCityCharts:
     def create_climate_chart(
         cls,
         df: pd.DataFrame,
-        var_climate,
-    ):
+        var_climate: dict[str, list[Any]],
+    ) -> str:
         """
         :param df:
         :param var_climate:
@@ -231,15 +232,22 @@ class ReportCityCharts:
         varcli_keys = list(var_climate.keys())
         varcli_values = list(var_climate.values())
 
+        if not varcli_keys:
+            return ""
+
         df_climate = deepcopy(df[["SE", *varcli_keys]])
+        for column in varcli_keys:
+            df_climate[column] = pd.to_numeric(
+                df_climate[column], errors="coerce"
+            )
 
         df_climate["SE"] = df_climate.SE.map(
             lambda v: "%s/%s" % (str(v)[:4], str(v)[-2:])
         )
 
-        df_climate[f"threshold_{varcli_keys[0]}"] = var_climate.get(
+        df_climate[f"threshold_{varcli_keys[0]}"] = var_climate[
             varcli_keys[0]
-        )[1]
+        ][1]
 
         figure = make_subplots(specs=[[{"secondary_y": True}]])
         # Temperature
@@ -248,7 +256,8 @@ class ReportCityCharts:
                 x=df_climate["SE"],
                 y=df_climate[varcli_keys[0]],
                 name=f"{varcli_keys[0]}",
-                marker={"color": "rgb(255, 204, 153)"},
+                mode="lines",
+                line={"color": "rgb(255, 204, 153)", "width": 3},
                 customdata=df_climate[varcli_keys[1]]
                 if len(varcli_keys) == 2
                 else [None] * len(df_climate),
@@ -274,7 +283,8 @@ class ReportCityCharts:
                     varcli_values[0][1],
                     varcli_values[0][0][0:2],
                 ),
-                marker={"color": "rgb(255,150,0)"},
+                mode="lines",
+                line={"color": "rgb(255,150,0)", "width": 2},
                 hoverinfo="skip",
             ),
             secondary_y=False,
@@ -282,16 +292,17 @@ class ReportCityCharts:
 
         if len(varcli_keys) == 2:
 
-            df_climate[f"threshold_{varcli_keys[1]}"] = var_climate.get(
+            df_climate[f"threshold_{varcli_keys[1]}"] = var_climate[
                 varcli_keys[1]
-            )[1]
+            ][1]
             # Humidity
             figure.add_trace(
                 go.Scatter(
                     x=df_climate["SE"],
                     y=df_climate[varcli_keys[1]],
                     name=f"{varcli_keys[1]}",
-                    marker={"color": "rgb(173, 216, 230)"},
+                    mode="lines",
+                    line={"color": "rgb(173, 216, 230)", "width": 3},
                     hoverinfo="skip",
                 ),
                 secondary_y=True,
@@ -306,7 +317,8 @@ class ReportCityCharts:
                         varcli_values[1][1],
                         varcli_values[1][0][0:2],
                     ),
-                    marker={"color": "rgb(51, 172, 255)"},
+                    mode="lines",
+                    line={"color": "rgb(51, 172, 255)", "width": 2},
                     hoverinfo="skip",
                 ),
                 secondary_y=True,
@@ -365,4 +377,4 @@ class ReportCityCharts:
             height=550,
         )
 
-        return figure.to_html()
+        return figure.to_html(full_html=False, include_plotlyjs=False)

--- a/AlertaDengue/dados/templates/report_city.html
+++ b/AlertaDengue/dados/templates/report_city.html
@@ -346,19 +346,15 @@
 <script>
   $(document).ready(function(){
     var cssClasses = {
-      'verde': 'green-row',
-      'amarelo': 'yellow-row',
-      'laranja': 'orange-row',
-      'vermelho': 'red-row'
+      '{% translate "verde" %}': 'green-row',
+      '{% translate "amarelo" %}': 'yellow-row',
+      '{% translate "laranja" %}': 'orange-row',
+      '{% translate "vermelho" %}': 'red-row'
     };
-
-    function normalizeLevel(value) {
-      return $.trim(value).toLowerCase();
-    }
 
     function applyAlertRowClass(row) {
       var $row = $(row);
-      var level = normalizeLevel($row.find('td:last-child').text());
+      var level = $.trim($row.find('td:last-child').text());
 
       $row.removeClass('green-row yellow-row orange-row red-row');
 

--- a/AlertaDengue/dados/templates/report_city.html
+++ b/AlertaDengue/dados/templates/report_city.html
@@ -346,11 +346,18 @@
       '{% translate "amarelo" %}': 'yellow-row',
       '{% translate "laranja" %}': 'orange-row',
       '{% translate "vermelho" %}': 'red-row'
-    }
+    };
 
-    $('.table tr').each(function(i, obj){
-      $(this).addClass(cssClasses[$('td:last-child', this).text()]);
-    });
+    function applyAlertRowClass(row) {
+      var $row = $(row);
+      var level = $.trim($row.find('td:last-child').text());
+
+      $row.removeClass('green-row yellow-row orange-row red-row');
+
+      if (cssClasses[level]) {
+        $row.addClass(cssClasses[level]);
+      }
+    }
 
     $(document).ready( function () {
       $('.table').DataTable({
@@ -358,6 +365,14 @@
         "lengthMenu": [ 4, 8, 12 ],
         "order": [[ 0, "desc" ]],
         "searching": false,
+        "createdRow": function(row) {
+          applyAlertRowClass(row);
+        },
+        "drawCallback": function() {
+          $(this.api().rows({ page: 'current' }).nodes()).each(function() {
+            applyAlertRowClass(this);
+          });
+        },
         "language": {
           "url": "/static/libs/DataTables/i18n/pt_BR.json"
         }

--- a/AlertaDengue/dados/templates/report_city.html
+++ b/AlertaDengue/dados/templates/report_city.html
@@ -23,20 +23,24 @@
         font-weight: bold;
       }
 
-      .green-row td {
-        background: #8BFFB7;
+      .table-striped tbody tr.green-row > td,
+      .table tbody tr.green-row > td {
+        background: #8BFFB7 !important;
       }
 
-      .yellow-row td {
-        background: #FFEB5C;
+      .table-striped tbody tr.yellow-row > td,
+      .table tbody tr.yellow-row > td {
+        background: #FFEB5C !important;
       }
 
-      .orange-row td {
-        background: #FFCE5C;
+      .table-striped tbody tr.orange-row > td,
+      .table tbody tr.orange-row > td {
+        background: #FFCE5C !important;
       }
 
-      .red-row td {
-        background: #FF7C73;
+      .table-striped tbody tr.red-row > td,
+      .table tbody tr.red-row > td {
+        background: #FF7C73 !important;
       }
       .table.dataTable, .table td, .table th {
         border-collapse: collapse !important;
@@ -342,15 +346,19 @@
 <script>
   $(document).ready(function(){
     var cssClasses = {
-      '{% translate "verde" %}': 'green-row',
-      '{% translate "amarelo" %}': 'yellow-row',
-      '{% translate "laranja" %}': 'orange-row',
-      '{% translate "vermelho" %}': 'red-row'
+      'verde': 'green-row',
+      'amarelo': 'yellow-row',
+      'laranja': 'orange-row',
+      'vermelho': 'red-row'
     };
+
+    function normalizeLevel(value) {
+      return $.trim(value).toLowerCase();
+    }
 
     function applyAlertRowClass(row) {
       var $row = $(row);
-      var level = $.trim($row.find('td:last-child').text());
+      var level = normalizeLevel($row.find('td:last-child').text());
 
       $row.removeClass('green-row yellow-row orange-row red-row');
 

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -1014,15 +1014,6 @@ class ReportCityView(TemplateView):
 
         this_year = int(context["year_week"][:4])
 
-        climate_cols = [
-            "temp.min",
-            "temp.med",
-            "temp.max",
-            "umid.min",
-            "umid.med",
-            "umid.max",
-        ]
-
         if not df_dengue.empty:
             last_year_week_l.append(df_dengue.index.max())
             dengue_params = get_disease_params("dengue")
@@ -1048,7 +1039,7 @@ class ReportCityView(TemplateView):
                     chart_dengue_incidence = None
 
                 chart_dengue_climate = ReportCityCharts.create_climate_chart(
-                    df=df_dengue.reset_index()[["SE", *climate_cols]],
+                    df=df_dengue.reset_index()[["SE", *v_climate.keys()]],
                     var_climate=v_climate,
                 )
 
@@ -1086,7 +1077,7 @@ class ReportCityView(TemplateView):
                     chart_chik_incidence = None
 
                 chart_chik_climate = ReportCityCharts.create_climate_chart(
-                    df=df_chik.reset_index()[["SE", *climate_cols]],
+                    df=df_chik.reset_index()[["SE", *v_climate.keys()]],
                     var_climate=v_climate,
                 )
 
@@ -1126,7 +1117,7 @@ class ReportCityView(TemplateView):
                 # Zika climate chart is usually not shown separately in the template,
                 # but we keep it here for consistency if needed.
                 chart_zika_climate = ReportCityCharts.create_climate_chart(
-                    df=df_zika.reset_index()[["SE", *climate_cols]],
+                    df=df_zika.reset_index()[["SE", *v_climate.keys()]],
                     var_climate=v_climate,
                 )
 

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -108,6 +108,72 @@ def get_var_params(
     return {key: valid_climate_vars[key] for key in varcli_keys}, varcli_keys
 
 
+def _format_report_table_value(
+    value: Any,
+    decimal_places: int = 0,
+) -> str:
+    """Format numeric report values with stable precision."""
+    if pd.isna(value):
+        return ""
+
+    numeric_value = pd.to_numeric(value, errors="coerce")
+    if pd.isna(numeric_value):
+        return str(value)
+
+    format_spec = f".{decimal_places}f"
+    return format(float(numeric_value), format_spec)
+
+
+def get_report_table_html(df: pd.DataFrame, keys: list[str]) -> str:
+    """Render the report table with per-column formatting."""
+    table_df = (
+        df[
+            [
+                *keys,
+                "casos notif.",
+                "casos_est",
+                "incidência",
+                "nivel",
+            ]
+        ]
+        .iloc[-12:, :]
+        .reset_index()
+        .sort_values(by="SE", ascending=[False])
+    )
+
+    climate_formatters = {
+        key: (
+            lambda value, decimal_places=1: _format_report_table_value(
+                value, decimal_places=decimal_places
+            )
+        )
+        for key in keys
+    }
+
+    formatters = {
+        "SE": lambda value: _format_report_table_value(
+            value, decimal_places=0
+        ),
+        **climate_formatters,
+        "casos notif.": lambda value: _format_report_table_value(
+            value, decimal_places=0
+        ),
+        "casos_est": lambda value: _format_report_table_value(
+            value, decimal_places=0
+        ),
+        "incidência": lambda value: _format_report_table_value(
+            value, decimal_places=1
+        ),
+    }
+
+    return table_df.to_html(
+        na_rep="",
+        index=False,
+        classes="table table-striped table-bordered",
+        formatters=formatters,
+    )
+
+
 def get_static(static_dir):
     if not settings.DEBUG:
         return Path(static(static_dir))
@@ -122,7 +188,7 @@ except locale.Error:
     logger.warning("pt_BR.UTF-8 locale is unavailable; using process default")
 
 
-def _get_disease_label(disease_code: str) -> str:
+def _get_disease_label(disease_code: str) -> str | None:
     return (
         "Dengue"
         if disease_code == "dengue"
@@ -886,14 +952,6 @@ class ReportCityView(TemplateView):
         except City.DoesNotExist:
             return self.raise_error(context, error_message_city_doesnt_exist)
 
-        # param used by df.to_html
-        html_param = dict(
-            na_rep="",
-            float_format=lambda x: ("%d" % x) if not np.isnan(x) else "",
-            index=False,
-            classes="table table-striped table-bordered",
-        )
-
         def get_disease_params(disease_name: str) -> ReportParameters | None:
             try:
                 params = RegionalParameters.get_report_parameters(
@@ -917,22 +975,6 @@ class ReportCityView(TemplateView):
                 return None
             except Exception:
                 return None
-
-        prepare_html = (
-            lambda df, keys: df[
-                [
-                    *keys,
-                    "casos notif.",
-                    "casos_est",
-                    "incidência",
-                    "nivel",
-                ]
-            ]
-            .iloc[-12:, :]
-            .reset_index()
-            .sort_values(by="SE", ascending=[False])
-            .to_html(**html_param)
-        )
 
         df_dengue = ReportCity.read_disease_data(
             disease="dengue",
@@ -999,7 +1041,9 @@ class ReportCityView(TemplateView):
                         threshold_pos_epidemic=dengue_params.limiar_posseason,
                         threshold_epidemic=dengue_params.limiar_epidemico,
                     )
-                    context["df_dengue_html"] = prepare_html(df_dengue, v_keys)
+                    context["df_dengue_html"] = get_report_table_html(
+                        df_dengue, v_keys
+                    )
                 else:
                     chart_dengue_incidence = None
 
@@ -1035,7 +1079,9 @@ class ReportCityView(TemplateView):
                         threshold_pos_epidemic=chik_params.limiar_posseason,
                         threshold_epidemic=chik_params.limiar_epidemico,
                     )
-                    context["df_chik_html"] = prepare_html(df_chik, v_keys)
+                    context["df_chik_html"] = get_report_table_html(
+                        df_chik, v_keys
+                    )
                 else:
                     chart_chik_incidence = None
 
@@ -1071,7 +1117,9 @@ class ReportCityView(TemplateView):
                         threshold_pos_epidemic=zika_params.limiar_posseason,
                         threshold_epidemic=zika_params.limiar_epidemico,
                     )
-                    context["df_zika_html"] = prepare_html(df_zika, v_keys)
+                    context["df_zika_html"] = get_report_table_html(
+                        df_zika, v_keys
+                    )
                 else:
                     chart_zika_incidence = None
 
@@ -1105,8 +1153,6 @@ class ReportCityView(TemplateView):
 
         max_alert_code = int(np.nanmax(disease_last_code))
         max_alert_color = ALERT_COLOR[max_alert_code]
-
-        prepare_html = None
 
         last_year_week_s = str(last_year_week)
         last_year = last_year_week_s[:4]

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -124,6 +124,25 @@ def _format_report_table_value(
     return format(float(numeric_value), format_spec)
 
 
+ALERT_LEVEL_LABELS = {
+    "verde": "verde",
+    "amarelo": "amarelo",
+    "laranja": "laranja",
+    "vermelho": "vermelho",
+}
+
+
+def _format_alert_level(value: Any) -> str:
+    if pd.isna(value):
+        return ""
+
+    level = str(value).strip().lower()
+    if level in ALERT_LEVEL_LABELS:
+        return _(ALERT_LEVEL_LABELS[level])
+
+    return str(value)
+
+
 def get_report_table_html(df: pd.DataFrame, keys: list[str]) -> str:
     """Render the report table with per-column formatting."""
     table_df = (
@@ -164,6 +183,7 @@ def get_report_table_html(df: pd.DataFrame, keys: list[str]) -> str:
         "incidência": lambda value: _format_report_table_value(
             value, decimal_places=1
         ),
+        "nivel": _format_alert_level,
     }
 
     return table_df.to_html(

--- a/AlertaDengue/tests/dados/test_views.py
+++ b/AlertaDengue/tests/dados/test_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -119,3 +120,12 @@ def test_create_climate_chart_returns_empty_without_variables() -> None:
     df = pd.DataFrame({"SE": [202501]})
 
     assert ReportCityCharts.create_climate_chart(df=df, var_climate={}) == ""
+
+
+def test_report_city_template_uses_canonical_alert_level_mapping() -> None:
+    html = Path("AlertaDengue/dados/templates/report_city.html").read_text()
+
+    assert "'verde': 'green-row'" in html
+    assert "'amarelo': 'yellow-row'" in html
+    assert "function normalizeLevel(value)" in html
+    assert ".table-striped tbody tr.yellow-row > td" in html

--- a/AlertaDengue/tests/dados/test_views.py
+++ b/AlertaDengue/tests/dados/test_views.py
@@ -110,7 +110,8 @@ def test_create_climate_chart_coerces_numeric_series() -> None:
         var_climate={"temp.min": ["°C temperatura mínima", 18]},
     )
 
-    assert "temp.min" in html
+    assert "°C temperatura mínima" in html
+    assert "temp.min" not in html
     assert "Limiar favorável" in html
 
 

--- a/AlertaDengue/tests/dados/test_views.py
+++ b/AlertaDengue/tests/dados/test_views.py
@@ -12,6 +12,7 @@ import pytest
 from dados.charts.cities import ReportCityCharts
 from dados.dbdata import ReportParameters
 from dados.views import get_report_table_html, get_var_params
+from django.utils.translation import override
 
 
 def make_parameters(
@@ -96,6 +97,26 @@ def test_get_report_table_html_formats_climate_values() -> None:
     assert "20.1318714285714" not in html
     assert ">12<" in html
     assert ">44.4<" in html
+    assert ">verde<" in html
+
+
+def test_get_report_table_html_translates_alert_level() -> None:
+    df = pd.DataFrame(
+        {
+            "SE": [202501],
+            "temp.min": [Decimal("20.1")],
+            "casos notif.": [Decimal("12")],
+            "casos_est": [Decimal("18")],
+            "incidência": [Decimal("44.4")],
+            "nivel": ["amarelo"],
+        }
+    ).set_index("SE")
+
+    with override("en"):
+        html = get_report_table_html(df, ["temp.min"])
+
+    assert ">Yellow<" in html
+    assert ">amarelo<" not in html
 
 
 def test_create_climate_chart_coerces_numeric_series() -> None:
@@ -122,10 +143,10 @@ def test_create_climate_chart_returns_empty_without_variables() -> None:
     assert ReportCityCharts.create_climate_chart(df=df, var_climate={}) == ""
 
 
-def test_report_city_template_uses_canonical_alert_level_mapping() -> None:
+def test_report_city_template_uses_translated_alert_level_mapping() -> None:
     html = Path("AlertaDengue/dados/templates/report_city.html").read_text()
 
-    assert "'verde': 'green-row'" in html
-    assert "'amarelo': 'yellow-row'" in html
-    assert "function normalizeLevel(value)" in html
+    assert "'{% translate \"verde\" %}': 'green-row'" in html
+    assert "'{% translate \"amarelo\" %}': 'yellow-row'" in html
+    assert "function normalizeLevel(value)" not in html
     assert ".table-striped tbody tr.yellow-row > td" in html

--- a/AlertaDengue/tests/dados/test_views.py
+++ b/AlertaDengue/tests/dados/test_views.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 from typing import Any
 
+import pandas as pd
 import pytest
+from dados.charts.cities import ReportCityCharts
 from dados.dbdata import ReportParameters
-from dados.views import get_var_params
+from dados.views import get_report_table_html, get_var_params
 
 
 def make_parameters(
@@ -71,4 +74,47 @@ def test_report_parameters_are_immutable() -> None:
     parameters = make_parameters("temp_min", 22)
 
     with pytest.raises(AttributeError):
-        parameters.varcli = "temp_max"  # type: ignore[misc]
+        parameters.varcli = "temp_max"
+
+
+def test_get_report_table_html_formats_climate_values() -> None:
+    df = pd.DataFrame(
+        {
+            "SE": [202501],
+            "temp.min": [Decimal("20.1318714285714")],
+            "casos notif.": [Decimal("12")],
+            "casos_est": [Decimal("18")],
+            "incidência": [Decimal("44.44")],
+            "nivel": ["verde"],
+        }
+    ).set_index("SE")
+
+    html = get_report_table_html(df, ["temp.min"])
+
+    assert "20.1" in html
+    assert "20.1318714285714" not in html
+    assert ">12<" in html
+    assert ">44.4<" in html
+
+
+def test_create_climate_chart_coerces_numeric_series() -> None:
+    df = pd.DataFrame(
+        {
+            "SE": [202501, 202502],
+            "temp.min": [Decimal("20.1"), Decimal("21.2")],
+        }
+    )
+
+    html = ReportCityCharts.create_climate_chart(
+        df=df,
+        var_climate={"temp.min": ["°C temperatura mínima", 18]},
+    )
+
+    assert "temp.min" in html
+    assert "Limiar favorável" in html
+
+
+def test_create_climate_chart_returns_empty_without_variables() -> None:
+    df = pd.DataFrame({"SE": [202501]})
+
+    assert ReportCityCharts.create_climate_chart(df=df, var_climate={}) == ""


### PR DESCRIPTION
### Description:
- Closes #953, closes #954 by applying alert row classes after each DataTables draw, formatting climate values with stable precision in the city report tables, and coercing climate series to numeric data so temp.min renders consistently in the climate chart.