### PR TITLE
fix(ruff): apply safe Python lint fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,11 @@ repos:
       - id: debug-statements
       - id: check-builtin-literals
       - id: check-case-conflict
+      # These hooks are intentionally manual during the phased lint rollout.
+      # Run them explicitly with:
+      #   pre-commit run <hook-id> --hook-stage manual
       - id: check-docstring-first
+        stages: [manual]
       - id: detect-private-key
 
   - repo: local
@@ -34,6 +38,7 @@ repos:
         language: system
         files: ^AlertaDengue/(dados/templates|templates)/.*\.html$
         pass_filenames: true
+        stages: [manual]
 
       - id: djlint-django
         name: djLint check (Django)
@@ -41,6 +46,7 @@ repos:
         language: system
         files: ^AlertaDengue/(dados/templates|templates)/.*\.html$
         pass_filenames: true
+        stages: [manual]
 
       - id: ruff-format
         name: Ruff format
@@ -61,12 +67,14 @@ repos:
         entry: poetry run bandit --configfile pyproject.toml -iii -lll
         language: system
         files: ^AlertaDengue/.*\.py$
+        stages: [manual]
 
       - id: vulture
         name: Vulture
         entry: poetry run python scripts/run-vulture.py
         language: system
         files: ^AlertaDengue/.*\.py$
+        stages: [manual]
 
       - id: mccabe
         name: McCabe
@@ -80,6 +88,7 @@ repos:
         entry: bash scripts/run-mypy-precommit.sh
         language: system
         files: ^AlertaDengue/.*\.py$
+        stages: [manual]
 
       - id: prettier
         name: Prettier

--- a/AlertaDengue/ad_main/settings/dev.py
+++ b/AlertaDengue/ad_main/settings/dev.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ad_main.settings.base import *  # noqa: F401,F403
+from ad_main.settings.base import *  # noqa: F403
 
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
@@ -8,11 +8,12 @@ ALLOWED_HOSTS = ["*"]
 try:
     import django_extensions  # noqa: F401
 
-    INSTALLED_APPS = INSTALLED_APPS + ["django_extensions"]
+    INSTALLED_APPS = [*INSTALLED_APPS, "django_extensions"]
 except ImportError:
     pass
 
-MIDDLEWARE = BASE_MIDDLEWARE + [
+MIDDLEWARE = [
+    *BASE_MIDDLEWARE,
     "django_cprofile_middleware.middleware.ProfilerMiddleware",
 ]
 DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF = False

--- a/AlertaDengue/ad_main/settings/prod.py
+++ b/AlertaDengue/ad_main/settings/prod.py
@@ -1,12 +1,12 @@
-from ad_main.settings.base import *  # noqa: F401,F403
+from ad_main.settings.base import *  # noqa: F403
 
 DEBUG = False
 
-MIDDLEWARE = (
-    ["django.middleware.cache.UpdateCacheMiddleware"]
-    + BASE_MIDDLEWARE
-    + ["django.middleware.cache.FetchFromCacheMiddleware"]
-)
+MIDDLEWARE = [
+    "django.middleware.cache.UpdateCacheMiddleware",
+    *BASE_MIDDLEWARE,
+    "django.middleware.cache.FetchFromCacheMiddleware",
+]
 
 TEMPLATES = build_templates(debug=DEBUG)
 CACHES = build_caches(debug=DEBUG)

--- a/AlertaDengue/ad_main/settings/staging.py
+++ b/AlertaDengue/ad_main/settings/staging.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from ad_main.settings.prod import *  # noqa: F403,F401
+from ad_main.settings.prod import *  # noqa: F403
 
 
 def env_list(name: str, default: str = "") -> list[str]:
@@ -44,15 +44,15 @@ DEFAULT_ALLOWED_HOSTS = [
 
 CERTBOT_DOMAINS = env_list("CERTBOT_DOMAIN")
 
-ALLOWED_HOSTS = (
-    DEFAULT_ALLOWED_HOSTS
-    + env_list("ALLOWED_HOSTS")
-    + [
+ALLOWED_HOSTS = [
+    *DEFAULT_ALLOWED_HOSTS,
+    *env_list("ALLOWED_HOSTS"),
+    *[
         f"{prefix}{domain}"
         for prefix in ["www.", ""]
         for domain in CERTBOT_DOMAINS
-    ]
-)
+    ],
+]
 
 # CSRF Protection
 CSRF_TRUSTED_ORIGINS = env_list("CSRF_TRUSTED_ORIGINS")

--- a/AlertaDengue/ad_main/settings/testing.py
+++ b/AlertaDengue/ad_main/settings/testing.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
+import sys
 
-from ad_main.settings.dev import *  # noqa: F403
 from django.db import connections
 from django.db.models.signals import pre_migrate
 from django.dispatch import receiver
+
+from ad_main.settings.dev import *  # noqa: F403
 
 DEBUG = True
 

--- a/AlertaDengue/api/db.py
+++ b/AlertaDengue/api/db.py
@@ -1,12 +1,12 @@
-from typing import Any, Optional
-
-import pandas as pd
-from dados.dbdata import CID10, STATE_NAME, get_disease_suffix  # noqa:F401
+from typing import Optional
 
 # local
 from django.conf import settings
+import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine.base import Engine
+
+from dados.dbdata import CID10, STATE_NAME, get_disease_suffix  # noqa:F401
 
 DB_ENGINE = settings.DB_ENGINE
 
@@ -140,9 +140,7 @@ class NotificationQueries:
                     ON notif.municipio_geocodigo = municipio.geocodigo
             ) AS tb
             WHERE {}
-            """.format(
-            self._age_field, clean_filters
-        )
+            """.format(self._age_field, clean_filters)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))
@@ -170,9 +168,7 @@ class NotificationQueries:
                     ON notif.municipio_geocodigo = municipio.geocodigo
             ) AS tb
             WHERE {}
-            """.format(
-            self._age_field, dist_filters
-        )
+            """.format(self._age_field, dist_filters)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))
@@ -253,9 +249,7 @@ class NotificationQueries:
         {}
         GROUP BY age
         ORDER BY age
-        """.format(
-            self._age_field, _dist_filters, gender_filter
-        )
+        """.format(self._age_field, _dist_filters, gender_filter)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))
@@ -302,9 +296,7 @@ class NotificationQueries:
         WHERE {}
         GROUP BY age
         ORDER BY age
-        """.format(
-            self._age_field, _dist_filters
-        )
+        """.format(self._age_field, _dist_filters)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))
@@ -362,9 +354,7 @@ class NotificationQueries:
         ) AS tb
         WHERE {} AND cs_sexo IN ('F', 'M')
         GROUP BY cs_sexo;
-        """.format(
-            self._age_field, _dist_filters
-        )
+        """.format(self._age_field, _dist_filters)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))
@@ -390,12 +380,9 @@ class NotificationQueries:
         FROM public.epiyear_summary_materialized_view
         WHERE uf = :state_name{disease_filter}
         ORDER BY ano_notif, se_notif
-        """.format(
-            disease_filter=disease_filter
-        )
+        """.format(disease_filter=disease_filter)
 
         with db_engine.connect() as conn:
-
             result = conn.execute(text(sql_text_query), parameters)
             df = pd.DataFrame(result.fetchall(), columns=result.keys())
             return pd.crosstab(
@@ -424,9 +411,7 @@ class NotificationQueries:
         WHERE {}
         GROUP BY dt_week
         ORDER BY dt_week
-        """.format(
-            self._age_field, _dist_filters
-        )
+        """.format(self._age_field, _dist_filters)
 
         with db_engine.connect() as conn:
             result = conn.execute(text(sql))

--- a/AlertaDengue/api/internal/permissions.py
+++ b/AlertaDengue/api/internal/permissions.py
@@ -1,5 +1,6 @@
-from api.internal.constants import NOTIFICATION_API_GROUP_NAME
 from rest_framework.permissions import BasePermission
+
+from api.internal.constants import NOTIFICATION_API_GROUP_NAME
 
 
 class HasNotificationAPIAccess(BasePermission):

--- a/AlertaDengue/api/internal/services.py
+++ b/AlertaDengue/api/internal/services.py
@@ -1,8 +1,8 @@
 # api/internal/services.py
 
-import math
 from datetime import date, datetime
 from decimal import Decimal
+import math
 from typing import Any
 
 from django.db import connection

--- a/AlertaDengue/api/internal/urls.py
+++ b/AlertaDengue/api/internal/urls.py
@@ -1,5 +1,6 @@
-from api.internal.views import NotificationListView
 from django.urls import path
+
+from api.internal.views import NotificationListView
 
 app_name = "internal"
 

--- a/AlertaDengue/api/internal/views.py
+++ b/AlertaDengue/api/internal/views.py
@@ -1,9 +1,10 @@
-from api.internal.permissions import HasNotificationAPIAccess
-from api.internal.services import list_notifications
 from django.db import DatabaseError
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from api.internal.permissions import HasNotificationAPIAccess
+from api.internal.services import list_notifications
 
 
 class NotificationListView(APIView):

--- a/AlertaDengue/api/tests/test_views.py
+++ b/AlertaDengue/api/tests/test_views.py
@@ -3,9 +3,9 @@ import os
 import unittest
 
 import django
-import pandas as pd
 from django.test import TestCase
 from django.urls import reverse
+import pandas as pd
 
 # local
 from .. import settings

--- a/AlertaDengue/api/views.py
+++ b/AlertaDengue/api/views.py
@@ -1,9 +1,10 @@
-import json
 from datetime import datetime
+import json
 
-from dados.episem import episem
 from django.http import HttpResponse
 from django.views.generic.base import View
+
+from dados.episem import episem
 
 # local
 from .db import STATE_NAME, AlertCity, NotificationQueries

--- a/AlertaDengue/dados/charts/alerts.py
+++ b/AlertaDengue/dados/charts/alerts.py
@@ -1,12 +1,12 @@
 import json
 from time import mktime
 
+from django.utils.translation import gettext as _
 import pandas as pd
 import plotly.graph_objs as go
 
 # local
 from dados.dbdata import load_series
-from django.utils.translation import gettext as _
 
 
 def int_or_none(x):
@@ -93,7 +93,6 @@ class AlertCitiesCharts:
     def create_alert_chart(
         cls, geocode, nome, disease_label, disease_code="dengue", epiweek=0
     ):
-
         result = cls.prepare_data(
             geocode, nome, disease_label, disease_code, epiweek
         )

--- a/AlertaDengue/dados/charts/cities.py
+++ b/AlertaDengue/dados/charts/cities.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from typing import Any
 
+from django.utils.translation import gettext as _
 import pandas as pd
 import plotly.graph_objs as go
-from django.utils.translation import gettext as _
 from plotly.subplots import make_subplots
 
 
@@ -294,7 +294,6 @@ class ReportCityCharts:
         )
 
         if len(varcli_keys) == 2:
-
             df_climate[f"threshold_{varcli_keys[1]}"] = var_climate[
                 varcli_keys[1]
             ][1]

--- a/AlertaDengue/dados/charts/home.py
+++ b/AlertaDengue/dados/charts/home.py
@@ -4,10 +4,10 @@ Module for plotting in the homepage charts
 
 from copy import deepcopy
 
+from django.utils.translation import gettext as _
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objs as go
-from django.utils.translation import gettext as _
 
 
 def _create_scatter_chart(df: pd.DataFrame) -> go.Figure:

--- a/AlertaDengue/dados/charts/states.py
+++ b/AlertaDengue/dados/charts/states.py
@@ -4,10 +4,10 @@ Module for plotting charts in the states reports
 
 from copy import deepcopy
 
+from django.utils.translation import gettext as _
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objs as go
-from django.utils.translation import gettext as _
 
 # from plotly.subplots import make_subplots
 

--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -2,32 +2,27 @@
 
 from __future__ import annotations
 
-import json
-import logging
-import unicodedata
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from functools import lru_cache
+import logging
 from typing import (
     Any,
-    Callable,
     Final,
     List,
-    Literal,
     Optional,
     Tuple,
     TypeVar,
 )
+import unicodedata
 
-import numpy as np
-import pandas as pd
-import psycopg2
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.text import slugify
 from epiweeks import Week
+import numpy as np
+import pandas as pd
 from sqlalchemy import bindparam, text
 from sqlalchemy.engine import Engine, Row
 
@@ -713,9 +708,7 @@ def get_epiyears(
     FROM public.epiyear_summary_materialized_view
     WHERE uf = :state_name{disease_filter}
     ORDER BY ano_notif, se_notif
-    """.format(
-        disease_filter=disease_filter
-    )
+    """.format(disease_filter=disease_filter)
 
     with db_engine.connect() as conn:
         result = conn.execute(text(sql_text_query), parameters)
@@ -964,7 +957,7 @@ class ReportCity:
         # However, preserving the logic from original code: `ew_start = ew_end - 200`
 
         sql = f"""
-            SELECT 
+            SELECT
                 "SE" AS "SE",
                 casos AS "casos notif.",
                 casos_est AS "casos_est",
@@ -976,16 +969,16 @@ class ReportCity:
                 umidmin AS "umid.min",
                 umidmed AS "umid.med",
                 umidmax AS "umid.max",
-                CASE 
+                CASE
                     WHEN nivel = 1 THEN 'verde'
                     WHEN nivel = 2 THEN 'amarelo'
                     WHEN nivel = 3 THEN 'laranja'
                     WHEN nivel = 4 THEN 'vermelho'
-                    ELSE '-' 
+                    ELSE '-'
                 END AS nivel,
                 nivel AS level_code
             FROM "Municipio"."{table_name}"
-            WHERE 
+            WHERE
                 "SE" BETWEEN :ew_start AND :ew_end
                 AND municipio_geocodigo = :geocode
             ORDER BY "SE"
@@ -1023,8 +1016,8 @@ class ReportState:
         if res is None:
             uf_name = ALL_STATE_NAMES[state][0]
 
-            sql = f"""
-                SELECT 
+            sql = """
+                SELECT
                     m.id_regional AS id_regional,
                     m.regional AS nome_regional,
                     m.geocodigo AS municipio_geocodigo,
@@ -1094,7 +1087,7 @@ class ReportState:
                 m.nome AS municipio_nome
             FROM "Municipio"."{table_name}" AS h
             JOIN "Dengue_global"."Municipio" AS m ON h.municipio_geocodigo = m.geocodigo
-            WHERE 
+            WHERE
                 h."SE" BETWEEN :ew_start AND :ew_end
                 AND h.municipio_geocodigo IN :geocodes
             ORDER BY h."SE"

--- a/AlertaDengue/dados/geoutils.py
+++ b/AlertaDengue/dados/geoutils.py
@@ -1,5 +1,5 @@
-import numpy as np
 from geopandas import GeoDataFrame
+import numpy as np
 
 
 def extract_boundaries(gdf: GeoDataFrame):

--- a/AlertaDengue/dados/management/commands/backfill_casprov.py
+++ b/AlertaDengue/dados/management/commands/backfill_casprov.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Final
 
-import pandas as pd
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, transaction
+import pandas as pd
 
 KEY_COLUMNS: Final[list[str]] = ["municipio_geocodigo", "SE"]
 
@@ -67,7 +67,7 @@ def normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     df = df.rename(columns=rename_map)
 
-    required_columns = set(KEY_COLUMNS + ["casprov"])
+    required_columns = {*KEY_COLUMNS, "casprov"}
     missing = required_columns.difference(df.columns)
     if missing:
         raise CommandError(
@@ -208,7 +208,6 @@ def collect_diagnostics(
         stage_scope_filters.append(f's."SE" <= {until_epiweek}')
 
     target_scope_sql = " AND ".join(scope_filters)
-    stage_scope_sql = " AND ".join(stage_scope_filters)
 
     stage_rows = fetch_int(f"SELECT COUNT(*) FROM {stage_table};")
 

--- a/AlertaDengue/dados/management/commands/sync_geofiles.py
+++ b/AlertaDengue/dados/management/commands/sync_geofiles.py
@@ -3,17 +3,18 @@ import os
 from pathlib import Path
 from typing import Final, Sequence
 
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management.base import BaseCommand
 import fiona
 import geojson
 import geopandas as gpd
 import shapely
-from dados import dbdata, maps
-from django.conf import settings
-from django.core.cache import cache
-from django.core.management.base import BaseCommand
 from shapely.geometry import MultiPolygon, shape
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
+
+from dados import dbdata, maps
 
 from ...geoutils import extract_boundaries
 

--- a/AlertaDengue/dados/maps.py
+++ b/AlertaDengue/dados/maps.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Final
 
-import geojson
 from django.conf import settings
+import geojson
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 

--- a/AlertaDengue/dados/tasks.py
+++ b/AlertaDengue/dados/tasks.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from typing import Literal
 
-from ad_main.celeryapp import app
 from celery.schedules import crontab
-from dados.dbdata import ALL_STATE_NAMES
 from scanner.scanner import EpiScanner
+
+from ad_main.celeryapp import app
+from dados.dbdata import ALL_STATE_NAMES
 
 app.conf.beat_schedule = {
     "episcanner-dengue-current-year": {

--- a/AlertaDengue/dados/technical_reports.py
+++ b/AlertaDengue/dados/technical_reports.py
@@ -1,7 +1,6 @@
-import json
 from dataclasses import dataclass
+import json
 from pathlib import Path
-from typing import Any
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -111,8 +110,8 @@ def serve_technical_report_pdf(request, report_key="default", *args, **kwargs):
     response = FileResponse(
         pdf_path.open("rb"), content_type="application/pdf"
     )
-    response[
-        "Content-Disposition"
-    ] = f'inline; filename="{report.output_filename}"'
+    response["Content-Disposition"] = (
+        f'inline; filename="{report.output_filename}"'
+    )
 
     return response

--- a/AlertaDengue/dados/templatetags/home_components.py
+++ b/AlertaDengue/dados/templatetags/home_components.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict
 
-from dados.dbdata import STATE_NAME
 from django import template
+
+from dados.dbdata import STATE_NAME
 
 register = template.Library()
 

--- a/AlertaDengue/dados/templatetags/searchbox_component.py
+++ b/AlertaDengue/dados/templatetags/searchbox_component.py
@@ -1,8 +1,9 @@
-from dados.dbdata import STATE_NAME, RegionalParameters
-from dados.models import City
 from django import template
 from django.conf import settings
 from django.core.cache import cache
+
+from dados.dbdata import STATE_NAME, RegionalParameters
+from dados.models import City
 
 register = template.Library()
 

--- a/AlertaDengue/dados/urls.py
+++ b/AlertaDengue/dados/urls.py
@@ -1,8 +1,9 @@
-from dados.dbdata import STATE_NAME
 from django.shortcuts import redirect
 from django.urls import re_path
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
+
+from dados.dbdata import STATE_NAME
 
 # local
 from .views import (

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -1,14 +1,12 @@
+from collections import OrderedDict, defaultdict
+from copy import deepcopy
+from dataclasses import replace
 import datetime
 import json
 import locale
 import logging
-import os
-import random
-from collections import OrderedDict, defaultdict
-from copy import deepcopy
-from dataclasses import replace
-from datetime import timedelta
 from pathlib import Path, PurePath
+import random
 from typing import Any
 
 import numpy as np
@@ -17,19 +15,18 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 #
-from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.staticfiles.finders import find
 from django.core.cache import cache
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 
 # from django.shortcuts import redirect
 from django.templatetags.static import static
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
-from django.views.generic.base import TemplateView, View
+from django.views.generic.base import View
 from epiweeks import Week
 
 from . import models as M
@@ -233,8 +230,7 @@ def hex_to_rgb(value):
     value = value.lstrip("#")
     lv = len(value)
     return tuple(
-        int(value[i : i + lv // 3], 16)
-        for i in range(0, lv, lv // 3)  # noqa: E203
+        int(value[i : i + lv // 3], 16) for i in range(0, lv, lv // 3)
     )
 
 
@@ -341,7 +337,10 @@ class DataPublicServicesPageView(TemplateView):
 
                 options_cities = ""
                 for state_abbv, state_name in STATE_NAME.items():
-                    for (geocode, city_name,) in RegionalParameters.get_cities(
+                    for (
+                        geocode,
+                        city_name,
+                    ) in RegionalParameters.get_cities(
                         state_name=state_name
                     ).items():
                         options_cities += """
@@ -661,9 +660,9 @@ class ChartsMainView(TemplateView):
             )
 
             # count_cities_by_uf('Santa Catarina', 'dengue')
-            count_cities[disease][
-                state_abbv
-            ] = notif_resume.count_cities_by_uf(state_name, disease)
+            count_cities[disease][state_abbv] = (
+                notif_resume.count_cities_by_uf(state_name, disease)
+            )
 
             df = data_hist_uf(state_abbv=state_abbv, disease=disease)
 
@@ -752,7 +751,7 @@ class ChartsMainView(TemplateView):
 class GeoJsonView(View):
     def get(self, request, geocodigo, disease):
         cache_key = f"geojson_{geocodigo}"
-        geojson = cache.get(cache_key)  # NOQA F811
+        geojson = cache.get(cache_key)
 
         if not geojson:
             # Get the path of the GeoJSON file
@@ -776,9 +775,9 @@ class GeoJsonView(View):
 
         # Create the HTTP response with the GeoJSON
         response = HttpResponse(geojson, content_type="application/json")
-        response[
-            "Content-Disposition"
-        ] = f"attachment; filename={geocodigo}.json"
+        response["Content-Disposition"] = (
+            f"attachment; filename={geocodigo}.json"
+        )
         return response
 
     def get_geojson_path(self, geocodigo):
@@ -1150,7 +1149,6 @@ class ReportStateData(TemplateView):
     template_name = "components/report_state/report_state_charts.html"
 
     def get_context_data(self, **kwargs):
-
         context = super(ReportStateData, self).get_context_data(**kwargs)
         state_abbv = context["state"]
         year_week = int(context["year_week"])

--- a/AlertaDengue/ingestion/admin.py
+++ b/AlertaDengue/ingestion/admin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.contrib import admin
+
 from ingestion.models import Run
 
 

--- a/AlertaDengue/ingestion/management/commands/ingestion_enqueue_sinan.py
+++ b/AlertaDengue/ingestion/management/commands/ingestion_enqueue_sinan.py
@@ -8,6 +8,7 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandError
 from django.db import IntegrityError, transaction
 from django.utils import timezone
+
 from ingestion.models import Run, RunStatus, SourceFormat
 from ingestion.schemas import RunError
 from ingestion.tasks import enqueue_sinan_run
@@ -152,7 +153,7 @@ class Command(BaseCommand):
                 updated_fields.append("delivery_week")
 
             if updated_fields:
-                run.save(update_fields=updated_fields + ["updated_at"])
+                run.save(update_fields=[*updated_fields, "updated_at"])
                 self.stdout.write(
                     self.style.SUCCESS(
                         f"Updated fields: {', '.join(updated_fields)}"

--- a/AlertaDengue/ingestion/management/commands/ingestion_watcher.py
+++ b/AlertaDengue/ingestion/management/commands/ingestion_watcher.py
@@ -1,14 +1,15 @@
 """
 Standalone file-system watcher for SINAN ingestion.
 """
+
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 import shlex
 import subprocess
-import time
-from pathlib import Path
 from threading import Timer
+import time
 from typing import Protocol
 
 from loguru import logger
@@ -19,8 +20,7 @@ from watchdog.observers.polling import PollingObserver
 class FileAction(Protocol):
     """Protocol for pluggable processing actions."""
 
-    def __call__(self, src_path: str) -> None:
-        ...
+    def __call__(self, src_path: str) -> None: ...
 
 
 class CommandAction:

--- a/AlertaDengue/ingestion/management/commands/mover_sinan_data.py
+++ b/AlertaDengue/ingestion/management/commands/mover_sinan_data.py
@@ -2,19 +2,19 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator
 import csv
+from dataclasses import dataclass
 import datetime
 import hashlib
 import io
 import json
 import logging
 import os
+from pathlib import Path
 import re
 import shutil
 import sys
-from collections.abc import Iterator
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from dbfread import DBF

--- a/AlertaDengue/ingestion/models.py
+++ b/AlertaDengue/ingestion/models.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import uuid
 from typing import Any
+import uuid
 
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+
 from ingestion.schemas import RunError, RunMetadata
 
 

--- a/AlertaDengue/ingestion/services.py
+++ b/AlertaDengue/ingestion/services.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Iterator
 
 from django.conf import settings
 

--- a/AlertaDengue/ingestion/sources.py
+++ b/AlertaDengue/ingestion/sources.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import dataclass
 import importlib.util
 import io
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator
 

--- a/AlertaDengue/ingestion/tasks.py
+++ b/AlertaDengue/ingestion/tasks.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Protocol
+from typing import Any, Iterable
 
-import numpy as np
-import pandas as pd
 from celery import chain, shared_task
 from django.conf import settings
 from django.utils import timezone
+import numpy as np
+import pandas as pd
+from psycopg2.extras import execute_values
+
 from ingestion.models import Run, RunStatus, SourceFormat
 from ingestion.schemas import RunError, RunMetadata
 from ingestion.services import resolve_source_path
@@ -20,7 +21,6 @@ from ingestion.sinan_specs import (
     SINAN_SYNONYMS_FIELDS,
 )
 from ingestion.sources import iter_csv, iter_dbf, iter_parquet
-from psycopg2.extras import execute_values
 
 from .types import DataChunk
 

--- a/AlertaDengue/ingestion/tests.py
+++ b/AlertaDengue/ingestion/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/AlertaDengue/ingestion/utils.py
+++ b/AlertaDengue/ingestion/utils.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-import datetime as dt
 from collections import Counter
+import datetime as dt
 from typing import Any, Iterable, Iterator, Optional, Union, cast
 
+from dateutil.parser import parse
 import numpy as np
 import pandas as pd
-from dateutil.parser import parse
 from pandas.tseries.api import guess_datetime_format
 
 
 def chunk_gen(chunksize: int, totalsize: int) -> Iterator[tuple[int, int]]:
-
     chunks = totalsize // chunksize
     for i in range(chunks):
         yield i * chunksize, (i + 1) * chunksize

--- a/AlertaDengue/ingestion/views.py
+++ b/AlertaDengue/ingestion/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/AlertaDengue/manage.py
+++ b/AlertaDengue/manage.py
@@ -3,8 +3,8 @@
 """Django's command-line utility for administrative tasks."""
 
 import os
-import sys
 from pathlib import Path
+import sys
 
 
 def main() -> None:

--- a/AlertaDengue/tests/api/test_alert_city.py
+++ b/AlertaDengue/tests/api/test_alert_city.py
@@ -1,7 +1,8 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+
 from AlertaDengue.api.db import AlertCity
 
 
@@ -54,9 +55,7 @@ def test_alert_city_search_with_weeks(mock_engine):
     (
         args,
         kwargs,
-    ) = (
-        mock_engine.connect.return_value.__enter__.return_value.execute.call_args
-    )
+    ) = mock_engine.connect.return_value.__enter__.return_value.execute.call_args
     params = kwargs.get("parameters", args[1] if len(args) > 1 else {})
     assert params["ew_start"] == 202301
     assert params["ew_end"] == 202302

--- a/AlertaDengue/tests/api/test_notifications.py
+++ b/AlertaDengue/tests/api/test_notifications.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
-import pytest
-from api.internal.constants import NOTIFICATION_API_GROUP_NAME
 from django.contrib.auth.models import Group, User
 from django.db import connection
 from django.urls import reverse
+import pytest
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
+
+from api.internal.constants import NOTIFICATION_API_GROUP_NAME
 
 CURRENT_DIR = Path(__file__).resolve().parent.parent
 NOTIFICATION_SQL_FIXTURE = (

--- a/AlertaDengue/tests/conftest.py
+++ b/AlertaDengue/tests/conftest.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 
 import django
-import pytest
 from django.conf import settings
+import pytest
 from sqlalchemy.engine import Engine
 
 

--- a/AlertaDengue/tests/dados/dbdata/conftest.py
+++ b/AlertaDengue/tests/dados/dbdata/conftest.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-import pytest
 from django.conf import settings
+import pytest
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
@@ -156,7 +156,7 @@ def regional_parameters_tables(db_engine: Engine) -> Iterator[None]:
         conn.execute(
             text(
                 f"""
-            INSERT INTO "{schema}"."parameters" 
+            INSERT INTO "{schema}"."parameters"
             (municipio_geocodigo, cid10, varcli, clicrit, varcli2, clicrit2,
              limiar_preseason, limiar_posseason, limiar_epidemico)
             VALUES
@@ -262,7 +262,7 @@ def report_data_tables(db_engine: Engine) -> Iterator[None]:
         conn.execute(
             text(
                 """
-            INSERT INTO "Municipio"."Historico_alerta" 
+            INSERT INTO "Municipio"."Historico_alerta"
             ("SE", "data_iniSE", municipio_geocodigo, casos, casos_est, nivel, p_inc100k, p_rt1)
             VALUES
             (202401, '2024-01-01', 3304557, 10, 15, 2, 5.0, 0.8),
@@ -283,7 +283,7 @@ def report_data_tables(db_engine: Engine) -> Iterator[None]:
         conn.execute(
             text(
                 """
-            INSERT INTO "Dengue_global"."Municipio" (geocodigo, nome, uf, id_regional, regional) 
+            INSERT INTO "Dengue_global"."Municipio" (geocodigo, nome, uf, id_regional, regional)
             VALUES (3304557, 'Rio de Janeiro', 'Rio de Janeiro', 1, 'Metropolitana I')
         """
             )

--- a/AlertaDengue/tests/dados/dbdata/test_data_hist_uf.py
+++ b/AlertaDengue/tests/dados/dbdata/test_data_hist_uf.py
@@ -4,8 +4,9 @@ Contract tests for data_hist_uf().
 
 from __future__ import annotations
 
-from dados.dbdata import data_hist_uf
 from django.core.cache import cache
+
+from dados.dbdata import data_hist_uf
 
 
 def test_data_hist_uf_orders_desc(hist_uf_dengue_table: None) -> None:

--- a/AlertaDengue/tests/dados/dbdata/test_regional_parameters.py
+++ b/AlertaDengue/tests/dados/dbdata/test_regional_parameters.py
@@ -4,11 +4,13 @@ Tests for RegionalParameters class in dbdata.py.
 Covers the composite PK (municipio_geocodigo, cid10) parameters table
 and verifies that disease-specific filtering returns correct thresholds.
 """
+
 from __future__ import annotations
 
-import pytest
-from dados.dbdata import RegionalParameters
 from django.core.cache import cache
+import pytest
+
+from dados.dbdata import RegionalParameters
 
 
 @pytest.fixture(autouse=True)

--- a/AlertaDengue/tests/dados/dbdata/test_report_city.py
+++ b/AlertaDengue/tests/dados/dbdata/test_report_city.py
@@ -1,12 +1,13 @@
 """
 Tests for ReportCity class in dbdata.py.
 """
+
 from __future__ import annotations
 
-import pandas as pd
-import pytest
-from dados.dbdata import ReportCity
 from django.core.cache import cache
+import pytest
+
+from dados.dbdata import ReportCity
 
 
 @pytest.fixture(autouse=True)

--- a/AlertaDengue/tests/dados/dbdata/test_report_state.py
+++ b/AlertaDengue/tests/dados/dbdata/test_report_state.py
@@ -1,12 +1,13 @@
 """
 Tests for ReportState class in dbdata.py.
 """
+
 from __future__ import annotations
 
-import pandas as pd
-import pytest
-from dados.dbdata import ReportState
 from django.core.cache import cache
+import pytest
+
+from dados.dbdata import ReportState
 
 
 @pytest.fixture(autouse=True)

--- a/AlertaDengue/tests/dados/test_technical_report.py
+++ b/AlertaDengue/tests/dados/test_technical_report.py
@@ -2,12 +2,12 @@ import json
 from pathlib import Path
 from typing import Any
 
-import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+import pytest
 
 
 def _download_view() -> Any:

--- a/AlertaDengue/tests/dados/test_views.py
+++ b/AlertaDengue/tests/dados/test_views.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-import logging
 from decimal import Decimal
+import logging
 from pathlib import Path
 from typing import Any
 
+from django.utils.translation import override
 import pandas as pd
 import pytest
+
 from dados.charts.cities import ReportCityCharts
 from dados.dbdata import ReportParameters
 from dados.views import get_report_table_html, get_var_params
-from django.utils.translation import override
 
 
 def make_parameters(

--- a/AlertaDengue/tests/ingestion/test_ingestion_enqueue_manifest.py
+++ b/AlertaDengue/tests/ingestion/test_ingestion_enqueue_manifest.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from django.core.management import call_command
+import pytest
+
 from ingestion.management.commands import ingestion_enqueue_manifest as man
 
 

--- a/AlertaDengue/tests/ingestion/test_ingestion_enqueue_sinan.py
+++ b/AlertaDengue/tests/ingestion/test_ingestion_enqueue_sinan.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+import pytest
+
 from ingestion.management.commands import ingestion_enqueue_sinan as cmd
 from ingestion.models import Run, RunStatus
 
@@ -23,7 +24,7 @@ def _write_unique_csv(path: Path, *, token: str) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        "CID10;SEM_NOT\n" "A90;202605\n" f"{token}\n",
+        f"CID10;SEM_NOT\nA90;202605\n{token}\n",
         encoding="utf-8",
     )
 

--- a/AlertaDengue/tests/ingestion/test_ingestion_merge.py
+++ b/AlertaDengue/tests/ingestion/test_ingestion_merge.py
@@ -5,17 +5,18 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
-import pytest
 from django.conf import settings
 from django.utils import timezone
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
 from ingestion.models import Run, RunStatus, SourceFormat
 from ingestion.tasks import (
     SINAN_DEST_COLUMNS,
     sinan_merge_run,
     sinan_stage_run,
 )
-from sqlalchemy import text
-from sqlalchemy.engine import Engine
 
 _SINAN_TEST_COLUMNS: list[str] = [
     "ID_MUNICIP",

--- a/AlertaDengue/tests/ingestion/test_ingestion_watcher.py
+++ b/AlertaDengue/tests/ingestion/test_ingestion_watcher.py
@@ -1,17 +1,17 @@
 """Tests for the decoupled ingestion watcher."""
+
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
-import pytest
+from watchdog.events import FileSystemEvent
+
 from ingestion.management.commands.ingestion_watcher import (
     CommandAction,
     IngestionWatcherHandler,
     LogOnlyAction,
     _parse_extensions,
 )
-from watchdog.events import FileSystemEvent
 
 
 def _make_handler(

--- a/AlertaDengue/tests/ingestion/test_mover_sinan_data.py
+++ b/AlertaDengue/tests/ingestion/test_mover_sinan_data.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import json
-import sys
 from dataclasses import dataclass
+import json
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
+
 from ingestion.management.commands import mover_sinan_data as mover
 
 
@@ -32,7 +33,7 @@ def test_move_to_canonical_csv_dry_run_bucket_es(tmp_path: Path) -> None:
     src = tmp_path / "incoming" / "DENGON_ES_202605_Infodengue.csv"
     _write_csv(
         src,
-        "ID_AGRAVO;SEM_NOT;SG_UF_NOT\n" "A90;202605;ES\n" "A90;202605;ES\n",
+        "ID_AGRAVO;SEM_NOT;SG_UF_NOT\nA90;202605;ES\nA90;202605;ES\n",
     )
 
     imported_base = tmp_path / "imported"

--- a/AlertaDengue/tests/test_utils.py
+++ b/AlertaDengue/tests/test_utils.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import os
 from logging import getLogger
+import os
 
 import psycopg2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,13 @@ convention = "numpy"
 combine-as-imports = true
 force-sort-within-sections = true
 
+[tool.ruff.lint.per-file-ignores]
+# TODO: These settings modules still rely on wildcard imports from base/prod
+# settings and should be refactored away from F405 later.
+"AlertaDengue/ad_main/settings/dev.py" = ["F405"]
+"AlertaDengue/ad_main/settings/prod.py" = ["F405"]
+"AlertaDengue/ad_main/settings/staging.py" = ["F405"]
+
 [tool.ruff.format]
 quote-style = "double"
 


### PR DESCRIPTION
### Description:

Apply the first phase of the Ruff cleanup by addressing safe, mechanical
diagnostics without changing application behavior.
Epic: #985 
#### Changes

- Apply Ruff auto-fixes.
- Remove unused imports and variables.
- Normalize import ordering.
- Apply safe syntax modernizations.
- Add targeted Ruff per-file ignores for legacy Django settings modules.
- Keep later lint phases (djLint, Bandit, Vulture, and mypy) deferred.

#### Validation

- `ruff format`
- `ruff check`
- Current-phase pre-commit hooks