### PR TITLE
fix(ruff): apply safe Python lint fixes II

### DIFF
--- a/AlertaDengue/ad_main/settings/base.py
+++ b/AlertaDengue/ad_main/settings/base.py
@@ -5,7 +5,6 @@ This module contains configuration shared by all environments. Environment-
 specific overrides live in ``dev.py`` and ``prod.py``.
 """
 
-
 from __future__ import annotations
 
 import os
@@ -38,7 +37,7 @@ def read_admins(value: str) -> tuple[tuple[str, str], ...]:
         Parsed admins in Django's expected format.
     """
     if not value:
-        return tuple()
+        return ()
 
     pairs: list[tuple[str, str]] = []
     for item in value.split(","):
@@ -417,10 +416,10 @@ LEAFLET_CONFIG = {
     "DEFAULT_CENTER": (-22.907000, -43.431000),
     "DEFAULT_ZOOM": 8,
     "MAXIMUM_ZOOM": 13,
-    "TILES": ("http://{s}.basemaps.cartocdn.com/" "light_all/{z}/{x}/{y}.png"),
+    "TILES": ("http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"),
     "MINIMAP": False,
     "ATTRIBUTION_PREFIX": (
-        "Fonte: <a href=http://info.dengue.mat.br>" "info.dengue.mat.br</a>"
+        "Fonte: <a href=http://info.dengue.mat.br>info.dengue.mat.br</a>"
     ),
     "PLUGINS": {
         "cluster": {
@@ -456,7 +455,7 @@ if SENTRY_DSN:
     )
 
 PWA_APP_NAME = (
-    "Infodengue – Early warning system for arbovirus transmission "
+    "Infodengue - Early warning system for arbovirus transmission "
     "(dengue, chikungunya, and Zika)"
 )
 PWA_APP_SHORT_NAME = "Infodengue"

--- a/AlertaDengue/ad_main/urls.py
+++ b/AlertaDengue/ad_main/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     re_path(r"^admin/doc/", include("django.contrib.admindocs.urls")),
     re_path(r"^api/", include("api.urls")),
     re_path(r"^status/$", status),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    *static(settings.STATIC_URL, document_root=settings.STATIC_ROOT),
+]


### PR DESCRIPTION
## Description:

Apply the first Ruff cleanup phase with safe, mechanical Python changes.
Epic: #985.
### Changes

- normalize imports and remove unused imports
- apply safe Ruff syntax fixes
- add narrow `F405` ignores for legacy settings modules
- resolve the remaining Ruff baseline diagnostics
- keep Bandit, Vulture, mypy, and djLint deferred to later phases

### Validation

- Ruff format
- Ruff lint
- McCabe
- active pre-commit hooks