### PR TITLE
style(djlint): normalize Django templates

### DIFF
--- a/AlertaDengue/dados/templates/alert_state.html
+++ b/AlertaDengue/dados/templates/alert_state.html
@@ -1,7 +1,7 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load i18n static alert_state %}
 
-{% block title %}{{ state }}{% endblock %}
+{% block title %}{{ state }}{% endblock title %}
 
 {% block content %}
 <div class="container-fluid">
@@ -14,4 +14,4 @@
     <!-- Row para o mapa -->
 
 </div>
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/alerta_municipio.html
+++ b/AlertaDengue/dados/templates/alerta_municipio.html
@@ -1,12 +1,12 @@
-{% extends 'alert_base.html' %}
+{% extends "alert_base.html" %}
 
-{% load humanize i18n%}
+{% load humanize i18n %}
 {% load i18n %}
 {% load static %}
 
 {% block alert_js %}
 dataurls ;
-{% endblock %}
+{% endblock alert_js %}
 
 {% block alert_js_main_init %}
 info.update = function (props) {
@@ -16,4 +16,4 @@ info.update = function (props) {
 
 get_map_bounds = function() {return geojson.getBounds();};
 
-{% endblock %}
+{% endblock alert_js_main_init %}

--- a/AlertaDengue/dados/templates/components/alert_state/epi-years.html
+++ b/AlertaDengue/dados/templates/components/alert_state/epi-years.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% block epi_years %}
 <h1>ADD A MAP </h1>
-{% endblock %}
+{% endblock epi_years %}

--- a/AlertaDengue/dados/templates/components/home/home_search_city.html
+++ b/AlertaDengue/dados/templates/components/home/home_search_city.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% load searchbox_component %}
 
-
 {% block home_search_city %}
 
 <section class="card mb-0 p-0 home-section-card city-alert-search"
@@ -29,4 +28,4 @@
   </div>
 </section>
 
-{% endblock %}
+{% endblock home_search_city %}

--- a/AlertaDengue/dados/templates/components/home/home_state_epi_section.html
+++ b/AlertaDengue/dados/templates/components/home/home_state_epi_section.html
@@ -3,9 +3,7 @@
 {% load static %}
 {% load hashthis %}
 
-
 {% block home_state_epi_section %}
-
 
 <div class="card mb-0 p-0 home-section-card"
      id="state-epi-card">
@@ -28,7 +26,7 @@
             {% trans "Selecione um estado" %}
           </option>
           {% for abbr, name in states_name.items %}
-            <option value="{{ abbr }}"{% if abbr == 'RJ' %} selected{% endif %}>
+            <option value="{{ abbr }}"{% if abbr == "RJ" %} selected{% endif %}>
               {{ name }}
             </option>
           {% endfor %}
@@ -45,7 +43,7 @@
     </div>
   </div>
 </div>
-{% endblock %}
+{% endblock home_state_epi_section %}
 
 <script type="text/javascript">
   (function ($) {

--- a/AlertaDengue/dados/templates/components/report_state/collapse.html
+++ b/AlertaDengue/dados/templates/components/report_state/collapse.html
@@ -45,7 +45,7 @@
 
 </div>
 
-{% endblock %}
+{% endblock regional_collapse_component %}
 
 <script type="text/javascript">
 

--- a/AlertaDengue/dados/templates/dashboard_cities.html
+++ b/AlertaDengue/dados/templates/dashboard_cities.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load static %}
 {% block extra_head %}
-    {% load series %}
     <meta property="og:image" content="{% static '/img/screenshot.png' %}" />
     <meta property="og:image:secure_url" content="{% static '/img/screenshot.png' %}" />
     <style>
@@ -58,5 +57,4 @@
 {% endblocktranslate %}{% endblock title %}
 
 {% block content %}
-    {% total_series %}
-{% endblock content %}
+    {% endblock content %}

--- a/AlertaDengue/dados/templates/dashboard_cities.html
+++ b/AlertaDengue/dados/templates/dashboard_cities.html
@@ -1,10 +1,10 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load i18n %}
 {% load static %}
 {% block extra_head %}
     {% load series %}
-    <meta property="og:image" content="{% static '/img/screenshot.png' %}"/>
-    <meta property="og:image:secure_url" content="{% static '/img/screenshot.png' %}"/>
+    <meta property="og:image" content="{% static '/img/screenshot.png' %}" />
+    <meta property="og:image:secure_url" content="{% static '/img/screenshot.png' %}" />
     <style>
         .leaflet-container {
             height: 400px;
@@ -51,12 +51,12 @@
     <script src="{% static '/js/modules/exporting.js' %}"></script>
     <script src="{% static '/js/infodengue.js' %}"></script>
 
-{% endblock %}
+{% endblock extra_head %}
 
 {% block title %}{% blocktranslate %}
-  Situação da Dengue - {{ num_mun }} Municípios monitorados 
-{% endblocktranslate %}{% endblock %}
+  Situação da Dengue - {{ num_mun }} Municípios monitorados
+{% endblocktranslate %}{% endblock title %}
 
 {% block content %}
     {% total_series %}
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/details.html
+++ b/AlertaDengue/dados/templates/details.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load i18n %}
 {% load static %}
 
@@ -16,13 +16,12 @@
     <script src="{% static '/js/highcharts-more.js' %}"></script>
     <script src="{% static '/js/modules/exporting.js' %}"></script>
     <script src="{% static '/libs/jquery/jquery.sparkline.min.js' %}"></script>
-{% endblock %}
+{% endblock extra_head %}
 
-
-{% block title %}{% translate "Alerta Dengue Rio" %}{% endblock %}
+{% block title %}{% translate "Alerta Dengue Rio" %}{% endblock title %}
 
 {% block content %}
-    <br>
+    <br />
     {% for ap in APS %}
         <div id="alerta-chart-{{ ap }}" style="min-width: 500px; height: 400px; margin: 10px"
              data-highcharts-chart="{{ forloop.counter0 }}"></div>
@@ -173,5 +172,4 @@
     </script>
 
 
-
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/historico.html
+++ b/AlertaDengue/dados/templates/historico.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load i18n %}
 {% load static %}
 
@@ -15,10 +15,9 @@
     <script src="{% static '/js/highcharts.js' %}"></script>
     <script src="{% static '/js/highcharts-more.js' %}"></script>
     <script src="{% static '/js/modules/exporting.js' %}"></script>
-{% endblock %}
+{% endblock extra_head %}
 
-
-{% block title %}Séries Históricas{% endblock %}
+{% block title %}Séries Históricas{% endblock title %}
 
 {% block content %}
     <h4>{% translate "O Alerta de Dengue e calculado usando dados que incluem os apresentados abaixo." %}</h4>
@@ -138,5 +137,4 @@
     </script>
 
 
-
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/main.html
+++ b/AlertaDengue/dados/templates/main.html
@@ -1,12 +1,12 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load i18n static home_components lookup %}
 {% block extra_head %}
-<meta property="og:image" content="{% static 'img/screenshot.png' %}">
-<meta property="og:image:secure_url" content="{% static 'img/screenshot.png' %}">
+<meta property="og:image" content="{% static "img/screenshot.png" %}" />
+<meta property="og:image:secure_url" content="{% static "img/screenshot.png" %}" />
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 
-<link href="{% static 'css/home_sections_layout.css' %}" rel="stylesheet" type="text/css">
-<link href="{% static 'css/home_menu_buttons.css' %}" rel="stylesheet" type="text/css">
+<link href="{% static "css/home_sections_layout.css" %}" rel="stylesheet" type="text/css" />
+<link href="{% static "css/home_menu_buttons.css" %}" rel="stylesheet" type="text/css" />
 <style>
 #carouselTop .carousel-item--hero .home-banner-mobile-content {
   display: none;
@@ -79,7 +79,7 @@
   }
 }
 </style>
-{% endblock %}
+{% endblock extra_head %}
 
 {% block content %}
 <div class="container-fluid p-0 mb-1 mt-0">
@@ -107,4 +107,4 @@
     {% home_state_epi_section %}
   </section>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/mapadengue.html
+++ b/AlertaDengue/dados/templates/mapadengue.html
@@ -26,7 +26,7 @@
         <div id="progress-bar" style="display: none"></div>
     </div>
 
-    <h1>{% translate "Casos de Dengue no município do Rio de Janeiro, em <b id="ano">2010</b> segundo SINAN." %}</h1>
+    <h1>{% translate 'Casos de Dengue no município do Rio de Janeiro, em <b id="ano">2010</b> segundo SINAN.' %}</h1>
     <b>{% translate "Year: " %}</b> <select id="year">
     <option value="2010">2010</option>
     <option value="2011">2011</option>

--- a/AlertaDengue/dados/templates/products.html
+++ b/AlertaDengue/dados/templates/products.html
@@ -1,14 +1,14 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% load static %}
 {% load i18n %}
 
 {% block extra_head %}
-<link href="{% static 'css/home_sections_layout.css' %}" rel="stylesheet">
-<link href="{% static 'css/home_menu_buttons.css' %}" rel="stylesheet">
-<link href="{% static 'css/products.css' %}" rel="stylesheet">
-{% endblock %}
+<link href="{% static "css/home_sections_layout.css" %}" rel="stylesheet" />
+<link href="{% static "css/home_menu_buttons.css" %}" rel="stylesheet" />
+<link href="{% static "css/products.css" %}" rel="stylesheet" />
+{% endblock extra_head %}
 
-{% block title %}{% translate "Produtos" %}{% endblock %}
+{% block title %}{% translate "Produtos" %}{% endblock content %}
 
 {% block content %}
 <div class="py-4 py-lg-5">
@@ -103,7 +103,7 @@
       <div class="card-body">
         <ul class="mb-0">
           <li>
-            <a href="{% url 'dados:download_technical_report_pdf' report_key='epidemiological-situation-analysis-2026' %}">
+            <a href="{% url "dados:download_technical_report_pdf" report_key="epidemiological-situation-analysis-2026" %}">
               Análise de situação epidemiológica da dengue em ano de El Niño
             </a>
           </li>
@@ -118,7 +118,7 @@
             </a>
           </li>
           <li>
-            <a href="{% url 'dados:download_technical_report_pdf' report_key='technical-report-2023' %}">
+            <a href="{% url "dados:download_technical_report_pdf" report_key="technical-report-2023" %}">
               Reflexões sobre o risco de arboviroses em 2024
             </a>
           </li>
@@ -153,10 +153,10 @@
               <div class="products-webinar-item__title">
                 {% blocktrans trimmed %}Preparação para a temporada de dengue 2025: perspectivas de modelos preditivos (1º IMDC){% endblocktrans %}
               </div>
-              <div class="products-webinar-language-links" aria-label="{% trans 'Language-specific webinar recordings' %}">
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=9fVgqHS-Ksk" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open Portuguese webinar recording on YouTube' %}">PT</a>
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=lrgg_HIRPfI" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open English webinar recording on YouTube' %}">EN</a>
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=8ZENF-kK_VQ" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open Spanish webinar recording on YouTube' %}">ES</a>
+              <div class="products-webinar-language-links" aria-label="{% trans "Language-specific webinar recordings" %}">
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=9fVgqHS-Ksk" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open Portuguese webinar recording on YouTube" %}">PT</a>
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=lrgg_HIRPfI" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open English webinar recording on YouTube" %}">EN</a>
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=8ZENF-kK_VQ" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open Spanish webinar recording on YouTube" %}">ES</a>
               </div>
             </div>
           </li>
@@ -165,8 +165,8 @@
               <div class="products-webinar-item__title">
                 {% trans "Webinar for the official announcement of the results of the validation of the second IMDC" %}
               </div>
-              <div class="products-webinar-language-links" aria-label="{% trans 'Language-specific webinar recordings' %}">
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=YexrCASlqIE" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open English webinar recording on YouTube' %}">EN</a>
+              <div class="products-webinar-language-links" aria-label="{% trans "Language-specific webinar recordings" %}">
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=YexrCASlqIE" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open English webinar recording on YouTube" %}">EN</a>
               </div>
             </div>
           </li>
@@ -175,8 +175,8 @@
               <div class="products-webinar-item__title">
                 {% trans "Webinar with the official results and predictions for the upcoming season" %}
               </div>
-              <div class="products-webinar-language-links" aria-label="{% trans 'Language-specific webinar recordings' %}">
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=Sb3lv3hGwGg" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open English webinar recording on YouTube' %}">EN</a>
+              <div class="products-webinar-language-links" aria-label="{% trans "Language-specific webinar recordings" %}">
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=Sb3lv3hGwGg" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open English webinar recording on YouTube" %}">EN</a>
               </div>
             </div>
           </li>
@@ -185,10 +185,10 @@
               <div class="products-webinar-item__title">
                 {% blocktrans trimmed %}Preparação para a temporada de dengue 2026: perspectivas e modelos preditivos (2º IMDC){% endblocktrans %}
               </div>
-              <div class="products-webinar-language-links" aria-label="{% trans 'Language-specific webinar recordings' %}">
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=EXv7ZOci5Lw&t=2185s" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open Portuguese webinar recording on YouTube' %}">PT</a>
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=mXTe6UC-7WM" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open English webinar recording on YouTube' %}">EN</a>
-                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=If_6LrGCJfs&t=1s" target="_blank" rel="noopener noreferrer" aria-label="{% trans 'Open Spanish webinar recording on YouTube' %}">ES</a>
+              <div class="products-webinar-language-links" aria-label="{% trans "Language-specific webinar recordings" %}">
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=EXv7ZOci5Lw&t=2185s" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open Portuguese webinar recording on YouTube" %}">PT</a>
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=mXTe6UC-7WM" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open English webinar recording on YouTube" %}">EN</a>
+                <a class="products-webinar-language-link" href="https://www.youtube.com/watch?v=If_6LrGCJfs&t=1s" target="_blank" rel="noopener noreferrer" aria-label="{% trans "Open Spanish webinar recording on YouTube" %}">ES</a>
               </div>
             </div>
           </li>
@@ -441,4 +441,4 @@
     </div>
   </section>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/dados/templates/products.html
+++ b/AlertaDengue/dados/templates/products.html
@@ -8,7 +8,7 @@
 <link href="{% static "css/products.css" %}" rel="stylesheet" />
 {% endblock extra_head %}
 
-{% block title %}{% translate "Produtos" %}{% endblock content %}
+{% block title %}{% translate "Produtos" %}{% endblock title %}
 
 {% block content %}
 <div class="py-4 py-lg-5">

--- a/AlertaDengue/templates/components/navbar.html
+++ b/AlertaDengue/templates/components/navbar.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block menu-bar %}
-<nav class="site-navbar navbar navbar-expand-md navbar-dark" aria-label="{% trans 'Navegação principal' %}">
+<nav class="site-navbar navbar navbar-expand-md navbar-dark" aria-label="{% trans "Navegação principal" %}">
   <button
       class="navbar-toggler site-navbar-toggler site-navbar-toggler--nav ml-auto"
       type="button"
@@ -10,7 +10,7 @@
       data-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent"
       aria-expanded="false"
-      aria-label="{% trans 'Alternar navegação' %}">
+      aria-label="{% trans "Alternar navegação" %}">
     <span class="navbar-toggler-icon"></span>
   </button>
 
@@ -22,7 +22,7 @@
             href="{% url 'dados:main' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Página inicial com visão geral da situação das arboviroses e principais recursos do Infodengue.' %}">
+            title="{% trans "Página inicial com visão geral da situação das arboviroses e principais recursos do Infodengue." %}">
           <i class="fas fa-house" aria-hidden="true"></i>
           <span>{% translate "Início" %}</span>
         </a>
@@ -34,7 +34,7 @@
             href="{% url 'dados:data_public_services' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Acesse os dados por meio da API e de notebooks de documentação com exemplos.' %}">
+            title="{% trans "Acesse os dados por meio da API e de notebooks de documentação com exemplos." %}">
           <i class="fas fa-database" aria-hidden="true"></i>
           <span>{% translate "Dados" %}</span>
         </a>
@@ -46,7 +46,7 @@
             href="{% url 'dados:report' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Consulte relatórios municipais e estaduais com indicadores epidemiológicos e níveis de alerta.' %}">
+            title="{% trans "Consulte relatórios municipais e estaduais com indicadores epidemiológicos e níveis de alerta." %}">
           <i class="fas fa-chart-line" aria-hidden="true"></i>
           <span>{% translate "Relatórios" %}</span>
         </a>
@@ -58,7 +58,7 @@
             href="{% url 'dados:products' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Veja os relatórios, publicações, teses e ferramentas produzidas pela equipe do Infodengue.' %}">
+            title="{% trans "Veja os relatórios, publicações, teses e ferramentas produzidas pela equipe do Infodengue." %}">
           <i class="fas fa-box-open" aria-hidden="true"></i>
           <span>{% translate "Produtos" %}</span>
         </a>
@@ -70,7 +70,7 @@
             href="{% url 'dados:team' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Conheça a equipe responsável pelo desenvolvimento, manutenção e análise dos dados do Infodengue.' %}">
+            title="{% trans "Conheça a equipe responsável pelo desenvolvimento, manutenção e análise dos dados do Infodengue." %}">
           <i class="fas fa-users" aria-hidden="true"></i>
           <span>{% translate "Equipe" %}</span>
         </a>
@@ -82,7 +82,7 @@
             href="{% url 'dados:about' %}"
             data-toggle="tooltip"
             data-placement="bottom"
-            title="{% trans 'Informações sobre o projeto Infodengue, seus objetivos, histórico e principais parceiros.' %}">
+            title="{% trans "Informações sobre o projeto Infodengue, seus objetivos, histórico e principais parceiros." %}">
           <i class="fas fa-circle-info" aria-hidden="true"></i>
           <span>{% translate "Sobre nós" %}</span>
         </a>
@@ -91,4 +91,4 @@
 
   </div>
 </nav>
-{% endblock %}
+{% endblock menu-bar %}

--- a/AlertaDengue/templates/registration/login.html
+++ b/AlertaDengue/templates/registration/login.html
@@ -1,15 +1,15 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 
-{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />{% endblock extrastyle %}
 
-{% block bodyclass %}{{ block.super }} login{% endblock %}
+{% block bodyclass %}{{ block.super }} login{% endblock bodyclass %}
 
-{% block nav-global %}{% endblock %}
+{% block nav-global %}{% endblock nav-global %}
 
-{% block content_title %}{% endblock %}
+{% block content_title %}{% endblock content_title %}
 
-{% block breadcrumbs %}{% endblock %}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 
 {% block content %}
 {% if form.errors and not form.non_field_errors %}
@@ -34,14 +34,14 @@
   </div>
   <div class="form-row">
     {{ form.password.errors }}
-    <label for="id_password" class="required">{% translate 'Password:' %}</label> {{ form.password }}
+    <label for="id_password" class="required">{% translate "Password:" %}</label> {{ form.password }}
     <input type="hidden" name="next" value="{{ next }}" />
   </div>
   <div class="password-reset-link">
-    <a href="{% url 'password_reset' %}">{% translate 'Forgotten your password or username?' %}</a>
+    <a href="{% url "password_reset" %}">{% translate "Forgotten your password or username?" %}</a>
   </div>
   <div class="submit-row">
-    <label>&nbsp;</label><input type="submit" value="{% translate 'Log in' %}" />
+    <label>&nbsp;</label><input type="submit" value="{% translate "Log in" %}" />
   </div>
 </form>
 
@@ -49,4 +49,4 @@
 document.getElementById('id_username').focus()
 </script>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/AlertaDengue/templates/registration/password_reset_email.html
+++ b/AlertaDengue/templates/registration/password_reset_email.html
@@ -5,8 +5,8 @@
 
 {% translate "Por favor, visite a página a seguir e escolha uma nova senha:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
-{% endblock %}
+{{ protocol }}://{{ domain }}{% url "password_reset_confirm" uidb64=uid token=token %}
+{% endblock reset_link %}
 {% translate "Seu nome de usuário, caso você tenha esquecido, é:" %} {{ user.get_username }}
 
 {% translate "Obrigado por usar o Infodengue" %}

--- a/AlertaDengue/tests/dados/templates/test_template_syntax.py
+++ b/AlertaDengue/tests/dados/templates/test_template_syntax.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader import get_template
+from django.template.utils import get_app_template_dirs
+import pytest
+
+
+@pytest.mark.parametrize(
+    "template_name",
+    sorted(
+        {
+            path.relative_to(template_dir).as_posix()
+            for template_dir in (
+                *(Path(path) for path in settings.TEMPLATES[0]["DIRS"]),
+                *get_app_template_dirs("templates"),
+            )
+            if template_dir.exists()
+            for path in template_dir.rglob("*.html")
+        }
+    ),
+)
+def test_django_template_compiles(template_name: str) -> None:
+    get_template(template_name)


### PR DESCRIPTION
## Description:

Apply the second phase of the lint cleanup by normalizing Django templates with djLint.
Epic: #985.

### Changes

* normalize template formatting and block names
* fix template syntax issues found during compilation
* remove unused dashboard template tags
* add a test that compiles all Django templates

### Validation

* djLint
* Django system checks
* template compilation test
* active pre-commit hooks
