### PR TITLE
fix(types): clarify Django settings typing

### DIFF
--- a/AlertaDengue/ad_main/settings/base.py
+++ b/AlertaDengue/ad_main/settings/base.py
@@ -54,12 +54,11 @@ def read_admins(value: str) -> tuple[tuple[str, str], ...]:
 # parent.parent.parent.parent == /opt/services
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent.parent
 # APP_DIRS = BASE_DIR / "AlertaDengue"
-PROJECT_ROOT = BASE_DIR / "AlertaDengue"
+PROJECT_ROOT: Path = BASE_DIR / "AlertaDengue"
 
 SECRET_KEY = os.getenv("SECRET_KEY")
-ALLOWED_HOSTS = (
-    os.getenv("ALLOWED_HOSTS").split(",") if os.getenv("ALLOWED_HOSTS") else []
-)
+allowed_hosts = os.getenv("ALLOWED_HOSTS")
+ALLOWED_HOSTS = allowed_hosts.split(",") if allowed_hosts else []
 ADMINS = read_admins(os.getenv("ADMINS", ""))
 
 MAINTENANCE_MODE = os.getenv("MAINTENANCE", "False").lower() == "true"
@@ -106,7 +105,7 @@ LOCAL_APPS = [
     "ingestion",
 ]
 
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+INSTALLED_APPS: list[str] = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 BASE_MIDDLEWARE: list[str] = [
     "django.middleware.security.SecurityMiddleware",
@@ -156,7 +155,7 @@ DB_ENGINE_FACTORY = get_sqla_conn
 
 DATABASE_ROUTERS = ["manager.router.DatabaseAppsRouter"]
 
-DATABASE_APPS_MAPPING = {
+DATABASE_APPS_MAPPING: dict[str, str] = {
     "dados": "dados",
     "default": "default",
 }
@@ -253,7 +252,7 @@ MEDIA_URL = "/img/"
 IMPORTED_FILES_DIR = os.getenv(
     "IMPORTED_FILES_DIR", "/opt/services/ingestion/sinan/imported"
 )
-TECHNICAL_REPORTS_ROOT = Path(
+TECHNICAL_REPORTS_ROOT: Path = Path(
     os.getenv("TECHNICAL_REPORTS_ROOT") or "/opt/services/technical_reports"
 )
 

--- a/AlertaDengue/ad_main/settings/dev.py
+++ b/AlertaDengue/ad_main/settings/dev.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 from ad_main.settings.base import *  # noqa: F403
+from ad_main.settings.base import (
+    BASE_MIDDLEWARE,
+    INSTALLED_APPS,
+    build_caches,
+    build_result_backend,
+    build_templates,
+)
 
 DEBUG = True
 ALLOWED_HOSTS = ["*"]

--- a/AlertaDengue/ad_main/settings/prod.py
+++ b/AlertaDengue/ad_main/settings/prod.py
@@ -1,4 +1,10 @@
 from ad_main.settings.base import *  # noqa: F403
+from ad_main.settings.base import (
+    BASE_MIDDLEWARE,
+    build_caches,
+    build_result_backend,
+    build_templates,
+)
 
 DEBUG = False
 

--- a/AlertaDengue/ad_main/settings/staging.py
+++ b/AlertaDengue/ad_main/settings/staging.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from ad_main.settings.prod import *  # noqa: F403
+from ad_main.settings.prod import MIDDLEWARE, TEMPLATES
 
 
 def env_list(name: str, default: str = "") -> list[str]:

--- a/AlertaDengue/ad_main/settings/testing.py
+++ b/AlertaDengue/ad_main/settings/testing.py
@@ -8,6 +8,7 @@ from django.db import connections
 from django.db.models.signals import pre_migrate
 from django.dispatch import receiver
 
+from ad_main.settings.base import DATABASES, get_sqla_conn
 from ad_main.settings.dev import *  # noqa: F403
 
 DEBUG = True
@@ -59,12 +60,12 @@ def _configure_test_db(db: dict[str, object]) -> None:
         test_cfg["NAME"] = test_name
 
 
-for db in DATABASES.values():  # noqa: F405
+for db in DATABASES.values():
     _configure_test_db(db)
 
-PSQL_DB = DATABASES["default"]["TEST"]["NAME"]  # noqa: F405
-if "dbf" in DATABASES:  # noqa: F405
-    PSQL_DBF = DATABASES["dbf"]["TEST"]["NAME"]  # noqa: F405
+PSQL_DB = DATABASES["default"]["TEST"]["NAME"]
+if "dbf" in DATABASES:
+    PSQL_DBF = DATABASES["dbf"]["TEST"]["NAME"]
 else:
     PSQL_DBF = PSQL_DB
 
@@ -90,8 +91,8 @@ def _ensure_required_schemas(sender, using: str, **_kwargs: object) -> None:
         )
 
 
-DB_ENGINE = get_sqla_conn(psql_db=PSQL_DB)  # noqa: F405
-DB_ENGINE_FACTORY = get_sqla_conn  # noqa: F405
+DB_ENGINE = get_sqla_conn(psql_db=PSQL_DB)
+DB_ENGINE_FACTORY = get_sqla_conn
 
 CACHES = {
     "default": {

--- a/AlertaDengue/ad_main/typed_settings.py
+++ b/AlertaDengue/ad_main/typed_settings.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, cast
+
+from django.conf import settings
+from sqlalchemy.engine import Engine
+
+
+class _TypedSettings(Protocol):
+    DB_ENGINE: Engine
+    DATABASE_APPS_MAPPING: dict[str, str]
+    QUERY_CACHE_TIMEOUT: int
+    PROJECT_ROOT: Path
+    TECHNICAL_REPORTS_ROOT: Path
+
+
+typed_settings = cast(_TypedSettings, settings)
+
+
+def get_db_engine() -> Engine:
+    return typed_settings.DB_ENGINE
+
+
+def get_database_apps_mapping() -> dict[str, str]:
+    return typed_settings.DATABASE_APPS_MAPPING
+
+
+def get_query_cache_timeout() -> int:
+    return typed_settings.QUERY_CACHE_TIMEOUT
+
+
+def get_project_root() -> Path:
+    return typed_settings.PROJECT_ROOT
+
+
+def get_technical_reports_root() -> Path:
+    return typed_settings.TECHNICAL_REPORTS_ROOT

--- a/AlertaDengue/ad_main/urls.py
+++ b/AlertaDengue/ad_main/urls.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -12,6 +14,9 @@ def status(_request):
     return JsonResponse({"status": "ok"})
 
 
+static_url = cast(str, settings.STATIC_URL)
+static_root = cast(str, settings.STATIC_ROOT)
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("pwa.urls")),
@@ -23,5 +28,5 @@ urlpatterns = [
     re_path(r"^admin/doc/", include("django.contrib.admindocs.urls")),
     re_path(r"^api/", include("api.urls")),
     re_path(r"^status/$", status),
-    *static(settings.STATIC_URL, document_root=settings.STATIC_ROOT),
+    *static(static_url, document_root=static_root),
 ]

--- a/AlertaDengue/api/db.py
+++ b/AlertaDengue/api/db.py
@@ -1,14 +1,14 @@
 from typing import Optional
 
 # local
-from django.conf import settings
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine.base import Engine
 
+from ad_main.typed_settings import get_db_engine
 from dados.dbdata import CID10, STATE_NAME, get_disease_suffix  # noqa:F401
 
-DB_ENGINE = settings.DB_ENGINE
+DB_ENGINE = get_db_engine()
 
 
 class NotificationQueries:

--- a/AlertaDengue/dados/management/commands/sync_geofiles.py
+++ b/AlertaDengue/dados/management/commands/sync_geofiles.py
@@ -14,11 +14,12 @@ from shapely.geometry import MultiPolygon, shape
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
+from ad_main.typed_settings import get_db_engine, get_query_cache_timeout
 from dados import dbdata, maps
 
 from ...geoutils import extract_boundaries
 
-DB_ENGINE: Final[Engine] = settings.DB_ENGINE
+DB_ENGINE: Final[Engine] = get_db_engine()
 
 
 def get_all_active_cities(
@@ -43,7 +44,7 @@ def get_all_active_cities(
     with db_engine.connect() as conn:
         res = conn.execute(stmt).fetchall()
 
-    cache.set(cache_key, res, settings.QUERY_CACHE_TIMEOUT)
+    cache.set(cache_key, res, get_query_cache_timeout())
     return list(res)
 
 
@@ -133,7 +134,7 @@ class Command(BaseCommand):
         )
 
     def create_geojson_by_state(self, geojson_simplified_path):
-        geojson_codes_states = {
+        geojson_codes_states: dict[str, list[str]] = {
             state_code: [] for state_code in dbdata.STATE_NAME.keys()
         }
         for geocode, _, _, state_name in dbdata.get_all_active_cities_state():
@@ -181,7 +182,7 @@ class Command(BaseCommand):
         serve_static = (
             settings.STATICFILES_DIRS[0]
             if settings.DEBUG
-            else settings.STATIC_ROOT
+            else str(settings.STATIC_ROOT)
         )
         path_root = Path(serve_static)
         f_geojson_path = path_root / "geojson"

--- a/AlertaDengue/dados/maps.py
+++ b/AlertaDengue/dados/maps.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Final
 
-from django.conf import settings
 import geojson
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-DB_ENGINE: Final[Engine] = settings.DB_ENGINE
+from ad_main.typed_settings import get_db_engine
+
+DB_ENGINE: Final[Engine] = get_db_engine()
 
 
 def get_city_geojson(

--- a/AlertaDengue/dados/settings.py
+++ b/AlertaDengue/dados/settings.py
@@ -1,13 +1,24 @@
+from typing import cast
+
+from django.conf import settings as django_settings
+
 try:
     # to be used externally (such as notebooks science)
-    from AlertaDengue.ad_main import settings
+    from AlertaDengue.ad_main.settings.base import (
+        PSQL_DB,
+        PSQL_HOST,
+        PSQL_PASSWORD,
+        PSQL_PORT,
+        PSQL_USER,
+        QUERY_CACHE_TIMEOUT,
+    )
 except Exception:
-    from django.conf import settings
-
-
-PSQL_DB = settings.PSQL_DB
-PSQL_HOST = settings.PSQL_HOST
-PSQL_PASSWORD = settings.PSQL_PASSWORD
-PSQL_USER = settings.PSQL_USER
-PSQL_PORT = settings.PSQL_PORT
-QUERY_CACHE_TIMEOUT = settings.QUERY_CACHE_TIMEOUT
+    PSQL_DB = cast(str, getattr(django_settings, "PSQL_DB"))
+    PSQL_HOST = cast(str, getattr(django_settings, "PSQL_HOST"))
+    PSQL_PASSWORD = cast(str, getattr(django_settings, "PSQL_PASSWORD"))
+    PSQL_USER = cast(str, getattr(django_settings, "PSQL_USER"))
+    PSQL_PORT = cast(int, getattr(django_settings, "PSQL_PORT"))
+    QUERY_CACHE_TIMEOUT = cast(
+        int,
+        getattr(django_settings, "QUERY_CACHE_TIMEOUT"),
+    )

--- a/AlertaDengue/dados/technical_reports.py
+++ b/AlertaDengue/dados/technical_reports.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 import json
-from pathlib import Path
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import FileResponse, Http404
+
+from ad_main.typed_settings import get_technical_reports_root
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,7 +22,7 @@ def load_technical_reports_manifest() -> dict[str, TechnicalReport]:
     The manifest is expected to be located at:
     Path(settings.TECHNICAL_REPORTS_ROOT) / "technical_reports.json"
     """
-    root = Path(settings.TECHNICAL_REPORTS_ROOT)
+    root = get_technical_reports_root()
     manifest_path = root / "technical_reports.json"
 
     if not manifest_path.exists():
@@ -94,7 +94,7 @@ def serve_technical_report_pdf(
     if report is None:
         raise Http404("Technical Report PDF not found")
 
-    root = Path(settings.TECHNICAL_REPORTS_ROOT).resolve()
+    root = get_technical_reports_root().resolve()
 
     # Resolve path and check for traversal
     try:

--- a/AlertaDengue/dados/templatetags/searchbox_component.py
+++ b/AlertaDengue/dados/templatetags/searchbox_component.py
@@ -1,7 +1,7 @@
 from django import template
-from django.conf import settings
 from django.core.cache import cache
 
+from ad_main.typed_settings import get_query_cache_timeout
 from dados.dbdata import STATE_NAME, RegionalParameters
 from dados.models import City
 
@@ -32,7 +32,7 @@ def searchbox_component(context):
     cache.set(
         cache_name,
         options_cities,
-        settings.QUERY_CACHE_TIMEOUT,
+        get_query_cache_timeout(),
     )
 
     context = {

--- a/AlertaDengue/manager/router.py
+++ b/AlertaDengue/manager/router.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from ad_main.typed_settings import get_database_apps_mapping
+
 
 class DatabaseAppsRouter(object):
     """
@@ -19,15 +21,17 @@ class DatabaseAppsRouter(object):
     def db_for_read(self, model, **hints):
         """ "Point all read operations to the specific database."""
         db = None
-        if model._meta.app_label in settings.DATABASE_APPS_MAPPING:
-            db = settings.DATABASE_APPS_MAPPING[model._meta.app_label]
+        apps_mapping = get_database_apps_mapping()
+        if model._meta.app_label in apps_mapping:
+            db = apps_mapping[model._meta.app_label]
         return db
 
     def db_for_write(self, model, **hints):
         """Point all write operations to the specific database."""
         db = None
-        if model._meta.app_label in settings.DATABASE_APPS_MAPPING:
-            db = settings.DATABASE_APPS_MAPPING[model._meta.app_label]
+        apps_mapping = get_database_apps_mapping()
+        if model._meta.app_label in apps_mapping:
+            db = apps_mapping[model._meta.app_label]
         return db
 
     def allow_relation(self, obj1, obj2, **hints):
@@ -35,8 +39,9 @@ class DatabaseAppsRouter(object):
         label1 = obj1._meta.app_label
         label2 = obj2._meta.app_label
 
-        db_obj1 = settings.DATABASE_APPS_MAPPING.get(label1)
-        db_obj2 = settings.DATABASE_APPS_MAPPING.get(label2)
+        apps_mapping = get_database_apps_mapping()
+        db_obj1 = apps_mapping.get(label1)
+        db_obj2 = apps_mapping.get(label2)
 
         allow = None
 
@@ -53,7 +58,7 @@ class DatabaseAppsRouter(object):
     def allow_syncdb(self, db, model):
         """Make sure that apps only appear in the related database."""
         allow = None
-        apps_mapping = settings.DATABASE_APPS_MAPPING  # alias
+        apps_mapping = get_database_apps_mapping()
 
         if db in apps_mapping.values():
             allow = apps_mapping.get(model._meta.app_label) == db
@@ -68,7 +73,7 @@ class DatabaseAppsRouter(object):
         return allow
 
     def allow_migrate(self, db, app_label, **hints):
-        apps_mapping = settings.DATABASE_APPS_MAPPING  # alias
+        apps_mapping = get_database_apps_mapping()
         allow = True
 
         if "target_db" in hints:


### PR DESCRIPTION
## Description

Resolve the mypy errors related to Django settings inheritance and dynamic
settings access.

### Changes

- add explicit settings imports for mypy visibility
- add typed annotations to shared settings values
- centralize dynamic Django settings access in `typed_settings.py`
- update settings consumers to use the typed helpers
- preserve the existing runtime settings behavior

### Validation

- Ruff passed for all changed Python files
- targeted mypy passed for all Phase 5B files
- Django system check passed with testing settings
- full mypy baseline reduced from 103 to 55 errors

### Deferred

The remaining mypy errors are outside this settings-focused phase:

- `dados/views.py`
- `dados/dbdata.py`
- `dados/charts/home.py`
- `api/views.py`
- related tests

Epic: #985