### PR TITLE
fix(types): resolve isolated mypy errors

### DIFF
--- a/AlertaDengue/dados/charts/home.py
+++ b/AlertaDengue/dados/charts/home.py
@@ -271,7 +271,7 @@ def _create_indicator_chart(df: pd.DataFrame, state_abbv: str) -> go.Indicator:
     return fig.to_html(full_html=False, include_plotlyjs=False, config=config)
 
 
-def _create_stack_chart(df: pd.DataFrame) -> px.bar():
+def _create_stack_chart(df: pd.DataFrame) -> go.Figure:
     """
     Create chart of the epidemiological situation of cities
     by levels in the week.

--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -607,7 +607,9 @@ def load_series(
         cache.set(cache_key, result, QUERY_CACHE_TIMEOUT)
         return {key_str: None, key_int: None}
 
-    series = defaultdict(lambda: defaultdict(list))
+    series: dict[str, dict[str, object]] = defaultdict(
+        lambda: defaultdict(list)
+    )
 
     series[key_str]["dia"] = dados_alerta.data_iniSE.tolist()
     series[key_str]["nivel"] = dados_alerta.nivel.tolist()

--- a/AlertaDengue/tests/dados/test_tasks.py
+++ b/AlertaDengue/tests/dados/test_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import TypedDict
 from unittest.mock import patch
 
 from django.conf import settings
@@ -12,7 +13,14 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 TEST_YEAR = 2024
-CITIES = {
+
+
+class CityFixture(TypedDict):
+    name: str
+    geocodes: list[int]
+
+
+CITIES: dict[str, CityFixture] = {
     "RJ": {
         "name": "Rio de Janeiro",
         "geocodes": [3304557, 3303302],  # Rio de Janeiro, Niterói


### PR DESCRIPTION
## Description

Resolve a small set of isolated mypy errors without changing runtime behavior.

### Changes

- annotate the Plotly stack chart with `go.Figure`
- add an explicit type for the alert series structure in `dados/dbdata.py`
- introduce a `TypedDict` for the state fixture data used by the EpiScanner task tests
- preserve the existing chart output, data structure and test behavior

### Scope

- `dados/charts/home.py`
- `dados/dbdata.py`
- `tests/dados/test_tasks.py`

### Validation

- Ruff
- targeted mypy
- EpiScanner task tests
- Django system check
- full mypy baseline check

### Deferred

The remaining mypy errors are part of later phases, mainly:

- `dados/views.py`
- `api/views.py`
- `api/tests/test_views.py`

Epic: #985