### PR TITLE
fix(types): clarify API view typing

### DIFF
--- a/AlertaDengue/api/tests/test_views.py
+++ b/AlertaDengue/api/tests/test_views.py
@@ -1,20 +1,22 @@
 import io
 import os
+from typing import Final
 import unittest
 
 import django
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 import pandas as pd
 
 # local
-from .. import settings
-from ..db import MRJ_GEOCODE
+
+MRJ_GEOCODE: Final = 3304557
 
 
 class TestApiView(TestCase):
     def setUp(self):
-        settings.DATA_DIR = os.path.dirname(__file__)
+        setattr(settings, "DATA_DIR", os.path.dirname(__file__))
 
     def test_notification_reduced_csv_view(self):
         """
@@ -47,26 +49,28 @@ class TestApiView(TestCase):
     def test_alert_rj(self):
         geocode = MRJ_GEOCODE
         # test epidemic start week missing
+        missing_week_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "json",
+        }
         response = self.client.get(
-            reverse("api:alertcity"),
-            {"disease": "dengue", "geocode": geocode, "format": "json"},
+            reverse("api:alertcity"), missing_week_query
         )
         self.assertEqual(response.status_code, 200)
         result = response.json()
         assert result["error_message"] == "Epidemic start week sent is empty."
 
         # test json format
-        response = self.client.get(
-            reverse("api:alertcity"),
-            {
-                "disease": "dengue",
-                "geocode": geocode,
-                "format": "json",
-                "ew_start": 1,
-                "ew_end": 50,
-                "e_year": 2017,
-            },
-        )
+        json_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "json",
+            "ew_start": 1,
+            "ew_end": 50,
+            "e_year": 2017,
+        }
+        response = self.client.get(reverse("api:alertcity"), json_query)
         self.assertEqual(response.status_code, 200)
         result = response.json()
         assert "error_message" not in result
@@ -75,17 +79,15 @@ class TestApiView(TestCase):
             assert 201701 <= r["se"] <= 201750
 
         # test csv format
-        response = self.client.get(
-            reverse("api:alertcity"),
-            {
-                "disease": "dengue",
-                "geocode": geocode,
-                "format": "csv",
-                "ew_start": "1",
-                "ew_end": "50",
-                "e_year": "2017",
-            },
-        )
+        csv_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "csv",
+            "ew_start": "1",
+            "ew_end": "50",
+            "e_year": "2017",
+        }
+        response = self.client.get(reverse("api:alertcity"), csv_query)
         self.assertEqual(response.status_code, 200)
         buffer = io.BytesIO(response.content)
         df = pd.read_csv(buffer)
@@ -95,9 +97,13 @@ class TestApiView(TestCase):
     def test_alert_curitiba(self):
         geocode = 4106902
         # test epidemic start week missing
+        missing_week_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "json",
+        }
         response = self.client.get(
-            reverse("api:alertcity"),
-            {"disease": "dengue", "geocode": geocode, "format": "json"},
+            reverse("api:alertcity"), missing_week_query
         )
         self.assertEqual(response.status_code, 200)
         result = response.json()
@@ -105,17 +111,15 @@ class TestApiView(TestCase):
         assert result["error_message"] == "Epidemic start week sent is empty."
 
         # test json format
-        response = self.client.get(
-            reverse("api:alertcity"),
-            {
-                "disease": "dengue",
-                "geocode": geocode,
-                "format": "json",
-                "ew_start": 1,
-                "ew_end": 50,
-                "e_year": 2017,
-            },
-        )
+        json_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "json",
+            "ew_start": 1,
+            "ew_end": 50,
+            "e_year": 2017,
+        }
+        response = self.client.get(reverse("api:alertcity"), json_query)
 
         self.assertEqual(response.status_code, 200)
 
@@ -127,17 +131,15 @@ class TestApiView(TestCase):
             assert 201701 <= r["SE"] <= 201750
 
         # test csv format
-        response = self.client.get(
-            reverse("api:alertcity"),
-            {
-                "disease": "dengue",
-                "geocode": geocode,
-                "format": "csv",
-                "ew_start": "1",
-                "ew_end": "50",
-                "e_year": "2017",
-            },
-        )
+        csv_query: dict[str, str | int] = {
+            "disease": "dengue",
+            "geocode": geocode,
+            "format": "csv",
+            "ew_start": "1",
+            "ew_end": "50",
+            "e_year": "2017",
+        }
+        response = self.client.get(reverse("api:alertcity"), csv_query)
         self.assertEqual(response.status_code, 200)
         buffer = io.BytesIO(response.content)
         df = pd.read_csv(buffer)

--- a/AlertaDengue/api/views.py
+++ b/AlertaDengue/api/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import json
 
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.views.generic.base import View
 
 from dados.episem import episem
@@ -12,6 +12,8 @@ from .db import STATE_NAME, AlertCity, NotificationQueries
 
 class _GetMethod:
     """"""
+
+    request: HttpRequest
 
     def _get(self, param, default=None, cast=None, error_message=None):
         """
@@ -39,16 +41,12 @@ class NotificationReducedCSV_View(View, _GetMethod):
 
     _state_name = STATE_NAME
 
-    request = None
-
-    def get(self, request):
+    def get(self, request: HttpRequest) -> HttpResponse:
         """
 
         :param kwargs:
         :return:
         """
-        self.request = request
-
         state_name = self._get("state_abv", default="").upper()
 
         if state_name not in self._state_name:
@@ -105,10 +103,7 @@ class NotificationReducedCSV_View(View, _GetMethod):
 class AlertCityView(View, _GetMethod):
     """ """
 
-    request = None
-
-    def get(self, request):
-        self.request = request
+    def get(self, request: HttpRequest) -> HttpResponse:
         format = ""
 
         try:
@@ -201,10 +196,7 @@ class EpiYearWeekView(View, _GetMethod):
     JSON output
     """
 
-    request = None
-
-    def get(self, request):
-        self.request = request
+    def get(self, request: HttpRequest) -> HttpResponse:
         output_format = "json"
 
         try:


### PR DESCRIPTION
## Description

Resolve the remaining mypy errors in the API views and their tests without
changing endpoint behavior.

### Changes

- type Django request attributes and view method signatures
- remove invalid `request = None` placeholders from class-based views
- replace a stale production constant import with test-local fixture data
- clarify Django test-client query parameter types
- keep the existing API responses, routes and database queries unchanged

### Validation

- Ruff passed
- targeted mypy passed for the API files
- Django system check passed
- Phase 5D errors reduced from 10 to 0
- full mypy now reports only the deferred `dados/views.py` cluster

### Tests

The API test module executed with 3 skipped tests and one environment-related
failure because the test database does not contain:

`"Municipio"."Notificacao"`

This failure is unrelated to the typing changes.

### Deferred

- `dados/views.py`

Epic: #985