### PR TITLE
fix(types): clarify chart accumulator structures

### DIFF
--- a/AlertaDengue/dados/charts/home.py
+++ b/AlertaDengue/dados/charts/home.py
@@ -10,7 +10,7 @@ import plotly.express as px
 import plotly.graph_objs as go
 
 
-def _create_scatter_chart(df: pd.DataFrame) -> go.Figure:
+def _create_scatter_chart(df: pd.DataFrame) -> str:
     """
     Create chart with historical data from data cases and cases_est.
 
@@ -157,7 +157,7 @@ def _create_scatter_chart(df: pd.DataFrame) -> go.Figure:
     return fig.to_html(full_html=False, include_plotlyjs=False, config=config)
 
 
-def _create_indicator_chart(df: pd.DataFrame, state_abbv: str) -> go.Indicator:
+def _create_indicator_chart(df: pd.DataFrame, state_abbv: str) -> str:
     """
     Create the charts with the number of favorable cities for transmission
     when the receptivity is different from 0.
@@ -271,7 +271,7 @@ def _create_indicator_chart(df: pd.DataFrame, state_abbv: str) -> go.Indicator:
     return fig.to_html(full_html=False, include_plotlyjs=False, config=config)
 
 
-def _create_stack_chart(df: pd.DataFrame) -> go.Figure:
+def _create_stack_chart(df: pd.DataFrame) -> str:
     """
     Create chart of the epidemiological situation of cities
     by levels in the week.

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import replace
 import datetime
@@ -603,14 +603,27 @@ class ChartsMainView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(ChartsMainView, self).get_context_data(**kwargs)
 
-        create_scatter_chart = defaultdict(dict)
-        create_indicator_chart = defaultdict(dict)
-        create_stack_chart = defaultdict(dict)
-        count_cities = defaultdict(dict)
-        create_maps = defaultdict(dict)
-        last_se = defaultdict(dict)
-        empty_charts_count = defaultdict(dict)
-        states_alert = defaultdict(dict)
+        diseases = tuple(DISEASES_NAME)
+        create_scatter_chart: dict[str, dict[str, str]] = {
+            disease: {} for disease in diseases
+        }
+        create_indicator_chart: dict[str, dict[str, str]] = {
+            disease: {} for disease in diseases
+        }
+        create_stack_chart: dict[str, dict[str, str]] = {
+            disease: {} for disease in diseases
+        }
+        count_cities: dict[str, dict[str, int]] = {
+            disease: {} for disease in diseases
+        }
+        create_maps: dict[str, dict[str, str]] = {
+            disease: {} for disease in diseases
+        }
+        last_se: dict[str, str] = {}
+        empty_charts_count: dict[str, int] = {
+            disease: 0 for disease in diseases
+        }
+        states_alert: dict[str, str] = {}
         notif_resume = NotificationResume
 
         state_abbv = cast(str, context["state"])
@@ -618,13 +631,11 @@ class ChartsMainView(TemplateView):
         states_alert[state_abbv] = state_abbv
 
         # Use as an argument to fetch in database
-        for disease in tuple(DISEASES_NAME):
+        for disease in diseases:
             no_data_chart = f"""
                 <div class='alert alert-primary' align='center'>
                   There are insufficient data to generate the chart on {disease}
                 </div>"""
-
-            empty_charts_count[disease] = 0
 
             create_maps[disease][state_abbv] = self.get_img_map(
                 state_abbv, disease


### PR DESCRIPTION
## Description

Resolve the `ChartsMainView` accumulator typing errors by replacing ambiguous
`defaultdict(dict)` containers with explicitly typed dictionaries matching the
actual template context values.

### Changes

- add precise types for chart, map, count and state context structures
- initialize nested dictionaries for each configured disease
- use integer dictionaries for chart counters
- use string dictionaries for epidemiological week and state values
- reuse the configured disease tuple throughout the method
- correct chart helper return annotations from `go.Figure` to `str`, matching
  their actual HTML output

### Context structures

- chart mappings: `disease -> state -> HTML`
- city counts: `disease -> state -> count`
- maps: `disease -> state -> HTML`
- last epidemiological week: `state -> week`
- empty chart counts: `disease -> count`
- alert states: `state -> state abbreviation`

### Validation

- Ruff formatting and checks passed
- targeted mypy errors for the chart accumulator cluster were resolved
- Django system check passed
- existing template context keys and value shapes were preserved

### Deferred

The remaining `dados/views.py` typing issues are intentionally left for the
next phase:

- `GeoJsonView.get_last_color_alert`
- Django ORM manager typing for `City.objects`

Epic: #985