### PR TITLE
fix(types): resolve final view typing errors

### DIFF
--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -744,7 +744,7 @@ class GeoJsonView(View):
                 geojson_data = json.load(f)
 
             # Modify the properties of the GeoJSON with the alert color
-            hex_color = self.get_last_color_alert(
+            hex_color = get_last_color_alert(
                 geocodigo, disease, color_type="hex"
             )
             geojson_data["features"][0]["properties"]["fill"] = hex_color
@@ -901,7 +901,7 @@ class ReportCityView(TemplateView):
         )
 
         try:
-            city = City.objects.get(pk=int(geocode))
+            city = City._default_manager.get(pk=int(geocode))
         except City.DoesNotExist:
             return self.raise_error(context, error_message_city_doesnt_exist)
 


### PR DESCRIPTION
## Description

Resolve the final two mypy errors in `dados/views.py` without changing runtime
behavior.

### Changes

- call the existing module-level `get_last_color_alert` helper directly from
  `GeoJsonView`
- use Django's `_default_manager` for the `City` lookup, avoiding an unnecessary
  typing ignore for the dynamically generated `objects` manager

### Context

`GeoJsonView` previously attempted to call `get_last_color_alert` as an instance
method even though it is defined as a module-level helper.

The `City.objects` lookup was valid at runtime, but the dynamically generated
manager was not recognized by mypy. Using `_default_manager` preserves the same
default-manager query behavior while exposing a typed Django model API.

### Validation

- Ruff formatting and checks passed
- targeted mypy for `dados/views.py` reduced from 2 errors to 0
- Django system check passed
- GeoJSON generation and city lookup behavior remain unchanged

### Scope

- `AlertaDengue/dados/views.py`

No models, migrations, queries, routes or templates were changed.

Epic: #985