### PR TITLE
chore(deps): update episcanner-downloader to v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1519,7 +1519,7 @@ dev = ["mypy (>=1.15)"]
 
 [[package]]
 name = "episcanner-downloader"
-version = "1.1.0"
+version = "2.0.0"
 description = "Dashboard quickstart template"
 optional = false
 python-versions = ">=3.11,<3.12"
@@ -1546,8 +1546,8 @@ urllib3 = "1.26.15"
 [package.source]
 type = "git"
 url = "https://github.com/AlertaDengue/episcanner-downloader"
-reference = "1.1.0"
-resolved_reference = "43344b66024b9113da626c3289648165cd9be018"
+reference = "2.0.0"
+resolved_reference = "6eb955ecf97519cec9689298fe0ae6112a66c5ea"
 
 [[package]]
 name = "epiweeks"
@@ -4538,4 +4538,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "acb62458573150c68bca0afbf498a06aa1891a5ec945c4fda0d1d9fd6f7ed3e9"
+content-hash = "42ecd46764259f88e327c3362ee207f2954f57a4c4dc52685412973457de5ca6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ django-celery-beat = "^2.6.0"
 redis = "^5.0.1"
 django-redis = "^5.4.0"
 epiweeks = "^2.3.0"
-episcanner-downloader = { git = "https://github.com/AlertaDengue/episcanner-downloader", tag = "1.1.0" }
+episcanner-downloader = { git = "https://github.com/AlertaDengue/episcanner-downloader", tag = "2.0.0" }
 duckdb = "^0.9.2"
 urllib3 = "1.26.15"
 pyarrow = ">=15,<16"


### PR DESCRIPTION
This implements the fix of https://github.com/AlertaDengue/episcanner-downloader/issues/48