### PR TITLE
refactor(dados): decouple legacy state dashboard queries

### DIFF
--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -132,6 +132,12 @@ HIST_UF_MATERIALIZED_VIEWS: Final[dict[str, str]] = {
     "zika": "hist_uf_zika_materialized_view",
 }
 
+CITY_COUNT_MATERIALIZED_VIEWS: Final[dict[str, str]] = {
+    "dengue": "city_count_by_uf_dengue_materialized_view",
+    "chikungunya": "city_count_by_uf_chikungunya_materialized_view",
+    "zika": "city_count_by_uf_zika_materialized_view",
+}
+
 
 def _read_sql_df(
     engine: Engine,
@@ -172,6 +178,31 @@ def data_hist_uf(state_abbv: str, disease: str = "dengue") -> pd.DataFrame:
 
     cache.set(cache_name, res, QUERY_CACHE_TIMEOUT)
     return res
+
+
+def count_monitored_municipalities(
+    state_name: str,
+    disease: str,
+    db_engine: Engine = DB_ENGINE,
+) -> int:
+    """Return the established full-history municipality count (cached)."""
+    view = CITY_COUNT_MATERIALIZED_VIEWS.get(disease)
+    if view is None:
+        raise ValueError(f"Unsupported disease: {disease!r}")
+
+    cache_name = f"count_monitored_municipalities:{state_name}:{disease}"
+    cached = cache.get(cache_name)
+    if cached is not None:
+        return int(cached)
+
+    stmt = text(f"SELECT city_count FROM public.{view} WHERE uf = :state_name")
+    with db_engine.connect() as conn:
+        result = conn.execute(stmt, {"state_name": state_name})
+        value = result.scalar_one_or_none()
+
+    count = int(value) if value is not None else 0
+    cache.set(cache_name, count, QUERY_CACHE_TIMEOUT)
+    return count
 
 
 class RegionalParameters:

--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -719,90 +719,47 @@ def get_epiyears(
     return data
 
 
-class NotificationResume:
-    @staticmethod
-    def count_cities_by_uf(
-        uf: str,
-        disease: str = "dengue",
-        db_engine: Engine = DB_ENGINE,
-    ) -> int:
-        """Return number of cities for a UF and disease from a materialized view.
+def get_cities_alert_by_state(
+    state_name: str,
+    disease: str = "dengue",
+    db_engine: Engine = DB_ENGINE,
+    epi_year_week: int | None = None,
+) -> pd.DataFrame:
+    """Return city-level alert indicators for a given state and disease.
 
-        Parameters
-        ----------
-        uf
-            UF (e.g. "RJ").
-        disease
-            Disease key (e.g. "dengue").
-        db_engine
-            SQLAlchemy engine.
+    Parameters
+    ----------
+    state_name
+        State name (UF).
+    disease
+        One of: dengue, chikungunya, zika.
+    db_engine
+        SQLAlchemy engine.
+    epi_year_week
+        If provided, filters by epidemiological year-week.
 
-        Returns
-        -------
-        int
-            City count (0 if missing / error).
-        """
-        view_name = f"public.city_count_by_uf_{disease}_materialized_view"
-        stmt = text(
-            f"""
-            SELECT city_count
-            FROM {view_name}
-            WHERE uf = :uf
-            """
-        )
+    Returns
+    -------
+    pandas.DataFrame
+        Columns: municipio_geocodigo, nome, data_iniSE, level_alert
+        with id as index.
+    """
+    _disease = get_disease_suffix(disease)
+    cache_key = (
+        f"cities_alert_{slugify(state_name, allow_unicode=True)}_{disease}"
+    )
+    cities_alert = cache.get(cache_key)
 
-        try:
-            with db_engine.connect() as conn:
-                row = conn.execute(stmt, {"uf": uf}).fetchone()
-            return int(row[0]) if row else 0
-        except Exception:
-            logger.exception(
-                "count_cities_by_uf failed (uf=%s, disease=%s)", uf, disease
-            )
-            return 0
+    if cities_alert is not None:
+        logger.info("Cache found for key: %s", cache_key)
+        return cities_alert
 
-    @staticmethod
-    def get_cities_alert_by_state(
-        state_name: str,
-        disease: str = "dengue",
-        db_engine: Engine = DB_ENGINE,
-        epi_year_week: int | None = None,
-    ) -> pd.DataFrame:
-        """Return city-level alert indicators for a given state and disease.
+    logger.info("Cache NOT found for key: %s", cache_key)
 
-        Parameters
-        ----------
-        state_name
-            State name (UF).
-        disease
-            One of: dengue, chikungunya, zika.
-        db_engine
-            SQLAlchemy engine.
-        epi_year_week
-            If provided, filters by epidemiological year-week.
+    hist_table = f'"Municipio"."Historico_alerta{_disease}"'
 
-        Returns
-        -------
-        pandas.DataFrame
-            Columns: municipio_geocodigo, nome, data_iniSE, level_alert
-            with id as index.
-        """
-        _disease = get_disease_suffix(disease)
-        cache_key = (
-            f"cities_alert_{slugify(state_name, allow_unicode=True)}_{disease}"
-        )
-        cities_alert = cache.get(cache_key)
-
-        if cities_alert is not None:
-            logger.info("Cache found for key: %s", cache_key)
-            return cities_alert
-
-        logger.info("Cache NOT found for key: %s", cache_key)
-
-        hist_table = f'"Municipio"."Historico_alerta{_disease}"'
-
-        sql_parts: list[str] = [
-            f"""
+    sql_parts: list[str] = [
+        f"""
             SELECT
                 hist_alert.id,
                 hist_alert.municipio_geocodigo,
@@ -812,14 +769,14 @@ class NotificationResume:
             FROM {hist_table} AS hist_alert
             INNER JOIN "Dengue_global"."Municipio" AS municipio
                 ON hist_alert.municipio_geocodigo = municipio.geocodigo
-            """
-        ]
+        """
+    ]
 
-        params: dict[str, Any] = {"uf": state_name}
+    params: dict[str, Any] = {"uf": state_name}
 
-        if epi_year_week is None:
-            sql_parts.append(
-                f"""
+    if epi_year_week is None:
+        sql_parts.append(
+            f"""
                 INNER JOIN (
                     SELECT
                         alerta.municipio_geocodigo AS geocodigo,
@@ -833,103 +790,90 @@ class NotificationResume:
                     ON recent_alert.geocodigo = hist_alert.municipio_geocodigo
                    AND recent_alert."data_iniSE" = hist_alert."data_iniSE"
                 WHERE municipio.uf = :uf
-                """
-            )
-        else:
-            sql_parts.append(
-                """
+            """
+        )
+    else:
+        sql_parts.append(
+            """
                 WHERE hist_alert."SE" = :epi_year_week
                   AND municipio.uf = :uf
-                """
-            )
-            params["epi_year_week"] = epi_year_week
-
-        sql = "\n".join(sql_parts)
-
-        with db_engine.connect() as conn:
-            result = conn.execute(text(sql), params)
-            rows = result.mappings().all()
-
-        cities_alert = pd.DataFrame.from_records(rows)
-        cities_alert = cities_alert.reindex(
-            columns=[
-                "id",
-                "municipio_geocodigo",
-                "nome",
-                "data_iniSE",
-                "level_alert",
-            ]
+            """
         )
+        params["epi_year_week"] = epi_year_week
 
-        if not cities_alert.empty:
-            cities_alert["data_iniSE"] = pd.to_datetime(
-                cities_alert["data_iniSE"],
-                errors="coerce",
-            )
-            cities_alert = cities_alert.set_index("id")
+    sql = "\n".join(sql_parts)
 
-        cache.set(cache_key, cities_alert, QUERY_CACHE_TIMEOUT)
-        logger.info("Cache set for key: %s", cache_key)
+    with db_engine.connect() as conn:
+        result = conn.execute(text(sql), params)
+        rows = result.mappings().all()
 
-        return cities_alert
+    cities_alert = pd.DataFrame.from_records(rows)
+    cities_alert = cities_alert.reindex(
+        columns=[
+            "id",
+            "municipio_geocodigo",
+            "nome",
+            "data_iniSE",
+            "level_alert",
+        ]
+    )
 
-    @staticmethod
-    def tail_estimated_cases(
-        geo_ids: list[int],
-        n: int = 12,
-        db_engine: Engine = DB_ENGINE,
-    ) -> pd.DataFrame:
-        """Fetch the last `n` estimated cases rows per municipality.
+    if not cities_alert.empty:
+        cities_alert["data_iniSE"] = pd.to_datetime(
+            cities_alert["data_iniSE"],
+            errors="coerce",
+        )
+        cities_alert = cities_alert.set_index("id")
 
-        Parameters
-        ----------
-        geo_ids
-            Municipality geocodes.
-        n
-            Number of weeks to fetch per municipality.
-        db_engine
-            SQLAlchemy engine.
+    cache.set(cache_key, cities_alert, QUERY_CACHE_TIMEOUT)
+    logger.info("Cache set for key: %s", cache_key)
 
-        Returns
-        -------
-        pandas.DataFrame
-            Columns: municipio_geocodigo, data_iniSE, casos_est
+    return cities_alert
+
+
+def get_estimated_cases_by_cities(
+    geo_ids: list[int],
+    disease: str,
+    n: int = 12,
+    db_engine: Engine = DB_ENGINE,
+) -> pd.DataFrame:
+    """Fetch the last ``n`` disease-specific case rows per municipality."""
+    if disease not in CID10:
+        raise ValueError(f"Unsupported disease: {disease!r}")
+
+    columns = ["municipio_geocodigo", "data_iniSE", "casos_est"]
+    if not geo_ids:
+        return pd.DataFrame(columns=columns)
+
+    table_name = f"Historico_alerta{get_disease_suffix(disease)}"
+    stmt = text(
+        f"""
+        SELECT municipio_geocodigo, "data_iniSE", casos_est
+        FROM (
+            SELECT
+                municipio_geocodigo,
+                "data_iniSE",
+                casos_est,
+                row_number() OVER (
+                    PARTITION BY municipio_geocodigo
+                    ORDER BY "data_iniSE" DESC
+                ) AS rn
+            FROM "Municipio"."{table_name}"
+            WHERE municipio_geocodigo IN :geo_ids
+        ) t
+        WHERE rn <= :n
+        ORDER BY municipio_geocodigo, "data_iniSE"
         """
-        if not geo_ids:
-            return pd.DataFrame(
-                columns=["municipio_geocodigo", "data_iniSE", "casos_est"]
-            )
+    ).bindparams(bindparam("geo_ids", expanding=True))
 
-        stmt = text(
-            """
-            SELECT municipio_geocodigo, "data_iniSE", casos_est
-            FROM (
-                SELECT
-                    municipio_geocodigo,
-                    "data_iniSE",
-                    casos_est,
-                    row_number() OVER (
-                        PARTITION BY municipio_geocodigo
-                        ORDER BY "data_iniSE" DESC
-                    ) AS rn
-                FROM "Municipio".historico_casos
-                WHERE municipio_geocodigo IN :geo_ids
-            ) t
-            WHERE rn <= :n
-            ORDER BY municipio_geocodigo, "data_iniSE"
-            """
-        ).bindparams(bindparam("geo_ids", expanding=True))
+    with db_engine.connect() as conn:
+        result = conn.execute(stmt, {"geo_ids": geo_ids, "n": n})
+        rows = result.fetchall()
 
-        with db_engine.connect() as conn:
-            result = conn.execute(stmt, {"geo_ids": geo_ids, "n": n})
-            rows = result.fetchall()
-
-        df = pd.DataFrame(rows, columns=result.keys())
-        if not df.empty:
-            df["data_iniSE"] = pd.to_datetime(
-                df["data_iniSE"], errors="coerce"
-            )
-        return df
+    df = pd.DataFrame(rows, columns=result.keys())
+    if not df.empty:
+        df["data_iniSE"] = pd.to_datetime(df["data_iniSE"], errors="coerce")
+    return df
 
 
 class ReportCity:

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -51,6 +51,7 @@ from .dbdata import (  # get_notification_cases,
     ReportCity,
     ReportParameters,
     ReportState,
+    count_monitored_municipalities,
     data_hist_uf,
     get_cities_alert_by_state,
     get_city_alert,
@@ -232,13 +233,6 @@ def _get_disease_label(disease_code: str) -> str | None:
 
 def _get_state_name(state: str) -> str:
     return cast(str, STATE_NAME[state])
-
-
-def _count_municipalities(state_history: pd.DataFrame) -> int:
-    """Count distinct non-null municipalities in state-history data."""
-    if state_history.empty:
-        return 0
-    return int(state_history["municipio_geocodigo"].nunique(dropna=True))
 
 
 def hex_to_rgb(value):
@@ -633,6 +627,7 @@ class ChartsMainView(TemplateView):
         }
         states_alert: dict[str, str] = {}
         state_abbv = cast(str, context["state"])
+        state_name = _get_state_name(state_abbv)
         states_alert[state_abbv] = state_abbv
 
         # Use as an argument to fetch in database
@@ -647,7 +642,10 @@ class ChartsMainView(TemplateView):
             )
 
             df = data_hist_uf(state_abbv=state_abbv, disease=disease)
-            count_cities[disease][state_abbv] = _count_municipalities(df)
+            count_cities[disease][state_abbv] = count_monitored_municipalities(
+                state_name=state_name,
+                disease=disease,
+            )
 
             if disease == "dengue":
                 if not df.empty:

--- a/AlertaDengue/dados/views.py
+++ b/AlertaDengue/dados/views.py
@@ -47,13 +47,14 @@ from .dbdata import (  # get_notification_cases,
     STATE_INITIAL,
     STATE_NAME,
     UF_CODES,
-    NotificationResume,
     RegionalParameters,
     ReportCity,
     ReportParameters,
     ReportState,
     data_hist_uf,
+    get_cities_alert_by_state,
     get_city_alert,
+    get_estimated_cases_by_cities,
     get_last_alert,
     get_last_SE,
 )
@@ -231,6 +232,13 @@ def _get_disease_label(disease_code: str) -> str | None:
 
 def _get_state_name(state: str) -> str:
     return cast(str, STATE_NAME[state])
+
+
+def _count_municipalities(state_history: pd.DataFrame) -> int:
+    """Count distinct non-null municipalities in state-history data."""
+    if state_history.empty:
+        return 0
+    return int(state_history["municipio_geocodigo"].nunique(dropna=True))
 
 
 def hex_to_rgb(value):
@@ -624,10 +632,7 @@ class ChartsMainView(TemplateView):
             disease: 0 for disease in diseases
         }
         states_alert: dict[str, str] = {}
-        notif_resume = NotificationResume
-
         state_abbv = cast(str, context["state"])
-        state_name = _get_state_name(state_abbv)
         states_alert[state_abbv] = state_abbv
 
         # Use as an argument to fetch in database
@@ -641,12 +646,8 @@ class ChartsMainView(TemplateView):
                 state_abbv, disease
             )
 
-            # count_cities_by_uf('Santa Catarina', 'dengue')
-            count_cities[disease][state_abbv] = (
-                notif_resume.count_cities_by_uf(state_name, disease)
-            )
-
             df = data_hist_uf(state_abbv=state_abbv, disease=disease)
+            count_cities[disease][state_abbv] = _count_municipalities(df)
 
             if disease == "dengue":
                 if not df.empty:
@@ -1222,7 +1223,7 @@ class AlertaStateView(TemplateView):
         state = cast(str, context["state"])
         disease = cast(str, context["disease"])
 
-        cities_alert = NotificationResume.get_cities_alert_by_state(
+        cities_alert = get_cities_alert_by_state(
             _get_state_name(state),
             disease,
         )
@@ -1238,7 +1239,11 @@ class AlertaStateView(TemplateView):
         geo_ids = list(mun_dict.keys())
 
         if geo_ids:
-            df = NotificationResume.tail_estimated_cases(geo_ids, 12)
+            df = get_estimated_cases_by_cities(
+                geo_ids=geo_ids,
+                disease=disease,
+                n=12,
+            )
             if isinstance(df, pd.DataFrame) and not df.empty:
                 df = df.sort_values(["municipio_geocodigo", "data_iniSE"])
                 case_series = {

--- a/AlertaDengue/tests/dados/test_legacy_state_dashboard.py
+++ b/AlertaDengue/tests/dados/test_legacy_state_dashboard.py
@@ -12,43 +12,142 @@ import pytest
 from sqlalchemy.sql.elements import BindParameter
 
 from api.views import NotificationReducedCSV_View
-from dados.dbdata import get_estimated_cases_by_cities
+from dados.dbdata import (
+    QUERY_CACHE_TIMEOUT,
+    count_monitored_municipalities,
+    get_estimated_cases_by_cities,
+)
 from dados.views import (
     AlertaStateView,
     ChartsMainView,
-    _count_municipalities,
 )
 
 
 @pytest.mark.parametrize(
-    ("geocodes", "expected"),
+    ("disease", "view_name"),
     [
-        ([3304557, 3304557], 1),
-        ([3304557, 3550308], 2),
-        ([3304557, None, float("nan")], 1),
-        ([], 0),
+        ("dengue", "city_count_by_uf_dengue_materialized_view"),
+        (
+            "chikungunya",
+            "city_count_by_uf_chikungunya_materialized_view",
+        ),
+        ("zika", "city_count_by_uf_zika_materialized_view"),
     ],
 )
-def test_count_municipalities_uses_distinct_non_null_geocodes(
-    geocodes: list[object], expected: int
+@patch("dados.dbdata.cache")
+def test_monitored_count_uses_disease_view_and_binds_state(
+    query_cache: MagicMock,
+    disease: str,
+    view_name: str,
 ) -> None:
-    frame = pd.DataFrame({"municipio_geocodigo": geocodes})
+    engine = MagicMock()
+    result = (
+        engine.connect.return_value.__enter__.return_value.execute.return_value
+    )
+    result.scalar_one_or_none.return_value = 92
+    query_cache.get.return_value = None
 
-    count = _count_municipalities(frame)
+    count = count_monitored_municipalities(
+        state_name="Rio de Janeiro",
+        disease=disease,
+        db_engine=engine,
+    )
 
-    assert count == expected
+    statement, params = (
+        engine.connect.return_value.__enter__.return_value.execute.call_args.args
+    )
+    assert f"public.{view_name}" in str(statement)
+    assert "WHERE uf = :state_name" in str(statement)
+    assert params == {"state_name": "Rio de Janeiro"}
+    assert count == 92
     assert isinstance(count, int)
+    cache_key = f"count_monitored_municipalities:Rio de Janeiro:{disease}"
+    query_cache.get.assert_called_once_with(cache_key)
+    query_cache.set.assert_called_once_with(cache_key, 92, QUERY_CACHE_TIMEOUT)
 
 
-def test_count_municipalities_accepts_empty_state_history() -> None:
-    assert _count_municipalities(pd.DataFrame()) == 0
+def test_monitored_count_rejects_invalid_disease() -> None:
+    with pytest.raises(ValueError, match="Unsupported disease"):
+        count_monitored_municipalities("Rio de Janeiro", "influenza")
+
+
+@patch("dados.dbdata.cache")
+def test_monitored_count_returns_and_caches_zero_for_missing_row(
+    query_cache: MagicMock,
+) -> None:
+    engine = MagicMock()
+    result = (
+        engine.connect.return_value.__enter__.return_value.execute.return_value
+    )
+    result.scalar_one_or_none.return_value = None
+    query_cache.get.return_value = None
+
+    count = count_monitored_municipalities(
+        "Rio de Janeiro", "dengue", db_engine=engine
+    )
+
+    assert count == 0
+    assert isinstance(count, int)
+    cache_key = "count_monitored_municipalities:Rio de Janeiro:dengue"
+    query_cache.get.assert_called_once_with(cache_key)
+    query_cache.set.assert_called_once_with(cache_key, 0, QUERY_CACHE_TIMEOUT)
+
+
+@pytest.mark.parametrize("cached_count", [0, 92])
+@patch("dados.dbdata.cache")
+def test_monitored_count_cache_hit_does_not_connect(
+    query_cache: MagicMock,
+    cached_count: int,
+) -> None:
+    query_cache.get.return_value = cached_count
+    engine = MagicMock()
+
+    count = count_monitored_municipalities(
+        "Rio de Janeiro", "dengue", db_engine=engine
+    )
+
+    assert count == cached_count
+    assert isinstance(count, int)
+    query_cache.get.assert_called_once_with(
+        "count_monitored_municipalities:Rio de Janeiro:dengue"
+    )
+    query_cache.set.assert_not_called()
+    engine.connect.assert_not_called()
+
+
+@patch("dados.dbdata.cache")
+def test_monitored_count_cache_separates_state_and_disease(
+    query_cache: MagicMock,
+) -> None:
+    query_cache.get.side_effect = [78, 853]
+    engine = MagicMock()
+
+    assert (
+        count_monitored_municipalities(
+            "Espírito Santo", "zika", db_engine=engine
+        )
+        == 78
+    )
+    assert (
+        count_monitored_municipalities(
+            "Minas Gerais", "zika", db_engine=engine
+        )
+        == 853
+    )
+    assert query_cache.get.call_args_list == [
+        call("count_monitored_municipalities:Espírito Santo:zika"),
+        call("count_monitored_municipalities:Minas Gerais:zika"),
+    ]
+    engine.connect.assert_not_called()
 
 
 @patch("dados.views._create_stack_chart", return_value="stack")
 @patch("dados.views.data_hist_uf")
+@patch("dados.views.count_monitored_municipalities")
 @patch.object(ChartsMainView, "get_img_map", return_value="map")
 def test_charts_main_view_preserves_count_cities_context(
     _get_img_map: MagicMock,
+    monitored_count: MagicMock,
     data_hist_uf: MagicMock,
     _create_stack_chart: MagicMock,
 ) -> None:
@@ -69,14 +168,20 @@ def test_charts_main_view_preserves_count_cities_context(
         state_history([3304557]),
         state_history([3304557, 3550308, 4106902]),
     ]
+    monitored_count.side_effect = [92, 91, 90]
 
     context = ChartsMainView().get_context_data(state="RJ")
 
     assert context["count_cities"] == {
-        "dengue": {"RJ": 2},
-        "chikungunya": {"RJ": 1},
-        "zika": {"RJ": 3},
+        "dengue": {"RJ": 92},
+        "chikungunya": {"RJ": 91},
+        "zika": {"RJ": 90},
     }
+    assert monitored_count.call_args_list == [
+        call(state_name="Rio de Janeiro", disease="dengue"),
+        call(state_name="Rio de Janeiro", disease="chikungunya"),
+        call(state_name="Rio de Janeiro", disease="zika"),
+    ]
     assert data_hist_uf.call_args_list == [
         call(state_abbv="RJ", disease="dengue"),
         call(state_abbv="RJ", disease="chikungunya"),

--- a/AlertaDengue/tests/dados/test_legacy_state_dashboard.py
+++ b/AlertaDengue/tests/dados/test_legacy_state_dashboard.py
@@ -1,0 +1,259 @@
+"""Regression tests for the retained legacy state-dashboard query flow."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, call, patch
+
+from django.test import RequestFactory
+from django.urls import resolve, reverse
+import pandas as pd
+import pytest
+from sqlalchemy.sql.elements import BindParameter
+
+from api.views import NotificationReducedCSV_View
+from dados.dbdata import get_estimated_cases_by_cities
+from dados.views import (
+    AlertaStateView,
+    ChartsMainView,
+    _count_municipalities,
+)
+
+
+@pytest.mark.parametrize(
+    ("geocodes", "expected"),
+    [
+        ([3304557, 3304557], 1),
+        ([3304557, 3550308], 2),
+        ([3304557, None, float("nan")], 1),
+        ([], 0),
+    ],
+)
+def test_count_municipalities_uses_distinct_non_null_geocodes(
+    geocodes: list[object], expected: int
+) -> None:
+    frame = pd.DataFrame({"municipio_geocodigo": geocodes})
+
+    count = _count_municipalities(frame)
+
+    assert count == expected
+    assert isinstance(count, int)
+
+
+def test_count_municipalities_accepts_empty_state_history() -> None:
+    assert _count_municipalities(pd.DataFrame()) == 0
+
+
+@patch("dados.views._create_stack_chart", return_value="stack")
+@patch("dados.views.data_hist_uf")
+@patch.object(ChartsMainView, "get_img_map", return_value="map")
+def test_charts_main_view_preserves_count_cities_context(
+    _get_img_map: MagicMock,
+    data_hist_uf: MagicMock,
+    _create_stack_chart: MagicMock,
+) -> None:
+    def state_history(geocodes: list[int | None]) -> pd.DataFrame:
+        row_count = len(geocodes)
+        return pd.DataFrame(
+            {
+                "SE": [202502] * row_count,
+                "casos_est": [0] * row_count,
+                "casos": [0] * row_count,
+                "nivel": [1] * row_count,
+                "municipio_geocodigo": geocodes,
+            }
+        )
+
+    data_hist_uf.side_effect = [
+        state_history([3304557, 3304557, 3550308, None]),
+        state_history([3304557]),
+        state_history([3304557, 3550308, 4106902]),
+    ]
+
+    context = ChartsMainView().get_context_data(state="RJ")
+
+    assert context["count_cities"] == {
+        "dengue": {"RJ": 2},
+        "chikungunya": {"RJ": 1},
+        "zika": {"RJ": 3},
+    }
+    assert data_hist_uf.call_args_list == [
+        call(state_abbv="RJ", disease="dengue"),
+        call(state_abbv="RJ", disease="chikungunya"),
+        call(state_abbv="RJ", disease="zika"),
+    ]
+
+
+def _query_engine() -> MagicMock:
+    engine = MagicMock()
+    result = (
+        engine.connect.return_value.__enter__.return_value.execute.return_value
+    )
+    result.fetchall.return_value = [(3304557, date(2025, 1, 5), 12.5)]
+    result.keys.return_value = [
+        "municipio_geocodigo",
+        "data_iniSE",
+        "casos_est",
+    ]
+    return engine
+
+
+@pytest.mark.parametrize(
+    ("disease", "table_name"),
+    [
+        ("dengue", "Historico_alerta"),
+        ("chikungunya", "Historico_alerta_chik"),
+        ("zika", "Historico_alerta_zika"),
+    ],
+)
+def test_estimated_cases_select_only_the_disease_table(
+    disease: str, table_name: str
+) -> None:
+    engine = _query_engine()
+
+    frame = get_estimated_cases_by_cities(
+        [3304557], disease=disease, db_engine=engine
+    )
+
+    statement, params = (
+        engine.connect.return_value.__enter__.return_value.execute.call_args.args
+    )
+    sql = str(statement)
+    assert f'"Municipio"."{table_name}"' in sql
+    for other_table in {
+        "Historico_alerta",
+        "Historico_alerta_chik",
+        "Historico_alerta_zika",
+    } - {table_name}:
+        assert f'"Municipio"."{other_table}"' not in sql
+    assert params == {"geo_ids": [3304557], "n": 12}
+    assert frame["casos_est"].tolist() == [12.5]
+    assert list(frame.columns) == [
+        "municipio_geocodigo",
+        "data_iniSE",
+        "casos_est",
+    ]
+    assert pd.api.types.is_datetime64_any_dtype(frame["data_iniSE"])
+
+
+def test_estimated_cases_select_last_n_rows_per_municipality() -> None:
+    engine = _query_engine()
+
+    get_estimated_cases_by_cities(
+        [3304557, 3550308], disease="dengue", n=4, db_engine=engine
+    )
+
+    statement, params = (
+        engine.connect.return_value.__enter__.return_value.execute.call_args.args
+    )
+    sql = str(statement)
+    assert "PARTITION BY municipio_geocodigo" in sql
+    assert 'ORDER BY "data_iniSE" DESC' in sql
+    assert "WHERE rn <= :n" in sql
+    assert 'ORDER BY municipio_geocodigo, "data_iniSE"' in sql
+    assert params == {"geo_ids": [3304557, 3550308], "n": 4}
+    geo_ids_parameter = statement._bindparams["geo_ids"]
+    assert isinstance(geo_ids_parameter, BindParameter)
+    assert geo_ids_parameter.expanding is True
+    n_parameter = statement._bindparams["n"]
+    assert isinstance(n_parameter, BindParameter)
+    assert n_parameter.expanding is False
+
+
+def test_estimated_cases_empty_geocodes_do_not_query_database() -> None:
+    engine = MagicMock()
+
+    frame = get_estimated_cases_by_cities([], "dengue", db_engine=engine)
+
+    assert frame.empty
+    assert list(frame.columns) == [
+        "municipio_geocodigo",
+        "data_iniSE",
+        "casos_est",
+    ]
+    engine.connect.assert_not_called()
+
+
+def test_estimated_cases_reject_invalid_disease() -> None:
+    with pytest.raises(ValueError, match="Unsupported disease"):
+        get_estimated_cases_by_cities([], "influenza")
+
+
+@patch("dados.views.get_last_SE")
+@patch("dados.views.get_estimated_cases_by_cities")
+@patch("dados.views.get_cities_alert_by_state")
+def test_alerta_state_view_uses_route_disease_for_case_series(
+    get_cities_alert_by_state: MagicMock,
+    get_estimated_cases_by_cities: MagicMock,
+    get_last_se: MagicMock,
+) -> None:
+    get_cities_alert_by_state.return_value = pd.DataFrame(
+        {
+            "municipio_geocodigo": [3304557, 3550308],
+            "nome": ["Rio de Janeiro", "São Paulo"],
+            "level_alert": [1, 2],
+        }
+    )
+    get_estimated_cases_by_cities.return_value = pd.DataFrame(
+        {
+            "municipio_geocodigo": [3550308, 3304557, 3304557],
+            "data_iniSE": pd.to_datetime(
+                ["2025-01-12", "2025-01-12", "2025-01-05"]
+            ),
+            "casos_est": [20.0, 12.0, 10.0],
+        }
+    )
+    get_last_se.return_value.enddate.return_value = date(2025, 1, 12)
+
+    view = AlertaStateView()
+    context = view.get_context_data(state="RJ", disease="zika")
+
+    assert view.template_name == "state_cities.html"
+    get_cities_alert_by_state.assert_called_once_with("Rio de Janeiro", "zika")
+    get_estimated_cases_by_cities.assert_called_once_with(
+        geo_ids=[3304557, 3550308],
+        disease="zika",
+        n=12,
+    )
+    assert context["case_series"] == {
+        3304557: [10.0, 12.0],
+        3550308: [20.0],
+    }
+    assert context["disease_label"] == "Zika"
+
+
+def test_legacy_state_dashboard_route_remains_available() -> None:
+    path = reverse(
+        "dados:alerta_uf", kwargs={"state": "RJ", "disease": "zika"}
+    )
+    match = resolve(path)
+
+    assert path == "/alerta/RJ/zika"
+    assert match.url_name == "alerta_uf"
+    assert match.func.view_class is AlertaStateView
+
+
+@patch("api.views.NotificationQueries")
+def test_reduced_notification_api_contract(
+    notification_queries: MagicMock,
+) -> None:
+    notification_queries.return_value.get_disease_dist.return_value = (
+        pd.DataFrame(
+            {"casos": [3]}, index=pd.Index(["Dengue"], name="category")
+        )
+    )
+    request = RequestFactory().get(
+        "/api/notif_reduced",
+        {"state_abv": "RJ", "chart_type": "disease"},
+    )
+    path = reverse("api:notif_reduced")
+    match = resolve(path)
+
+    response = NotificationReducedCSV_View.as_view()(request)
+
+    assert path == "/api/notif_reduced"
+    assert match.func.view_class is NotificationReducedCSV_View
+    assert response.status_code == 200
+    assert b"category,casos" in response.content
+    assert b"Dengue,3" in response.content
+    notification_queries.assert_called_once()

--- a/docs/database/orm_inventory.md
+++ b/docs/database/orm_inventory.md
@@ -308,9 +308,15 @@ These objects are outside the original schema inventory scope. No database
 object is modified by this application-code change.
 
 - `public.city_count_by_uf_dengue_materialized_view`,
-  `public.city_count_by_uf_chik_materialized_view`, and
-  `public.city_count_by_uf_zika_materialized_view` are archival candidates after
-  deployment validation; their application query was replaced by a distinct
-  municipality count from the already-loaded disease-specific state history.
+  `public.city_count_by_uf_chikungunya_materialized_view`, and
+  `public.city_count_by_uf_zika_materialized_view` remain in use for the
+  homepage's existing monitored-municipality count. A direct full-history
+  count reproduced the existing values across all 81 UF/disease combinations,
+  but representative queries scanned millions of historical rows and were not
+  suitable for the homepage request path. These views therefore remain active
+  and are not archival candidates in this PR.
+- The retained count preserves the established “Municípios monitorados”
+  population. No database object is modified by this PR; any future physical
+  archival belongs to a separate reviewed database change.
 - `public.epiyear_summary_materialized_view` remains pending external-consumer
   verification because the public `/api/notif_reduced` endpoint is retained.

--- a/docs/database/orm_inventory.md
+++ b/docs/database/orm_inventory.md
@@ -173,7 +173,7 @@ not be confused with PostgreSQL schemas.
 | `alerta_mrj` | table | legacy | archive | do-not-map | unknown | `dengueadmin` | none | no runtime evidence found | PK `id`; unique `(aps, se)`; approx. rows `6274`; size `1114112` bytes | This table belongs to a retired reporting workflow. Maintainers approved archival and no ORM mapping. This PR records lifecycle and ORM decisions only. |
 | `alerta_mrj_chik` | table | legacy | archive | do-not-map | unknown | `dengueadmin` | none | no runtime evidence found | PK `id`; unique `(aps, se)`; approx. rows `6270`; size `1114112` bytes | This table belongs to a retired reporting workflow. Maintainers approved archival and no ORM mapping. This PR records lifecycle and ORM decisions only. |
 | `alerta_mrj_zika` | table | legacy | archive | do-not-map | unknown | `postgres` | none | no runtime evidence found | PK `id`; unique `(aps, se)`; size `24576` bytes | This table belongs to a retired reporting workflow. Maintainers approved archival and no ORM mapping. This PR records lifecycle and ORM decisions only. |
-| `historico_casos` | materialized view | legacy | archive | do-not-map | read-only | `dengueadmin` | none | raw SQL | no PK; approx. rows `4796063`; size `358580224` bytes | The materialized view is queried only by `NotificationResume.tail_estimated_cases()` in `dados/dbdata.py`. That method is currently called by `AlertaStateView` in `dados/views.py`, and `AlertaStateView` is currently registered for `/alerta/<state>/<disease>`. Maintainers have classified this flow as legacy. Physical archival of this materialized view requires a separate code change that removes or replaces this call path first. This PR records lifecycle and ORM decisions only. |
+| `historico_casos` | materialized view | legacy | archive | do-not-map | read-only | `dengueadmin` | none | no runtime evidence found | no PK; approx. rows `4796063`; size `358580224` bytes | Its incorrect disease-combining semantics were removed from the application by replacing the legacy dashboard query with disease-specific `Historico_alerta*` queries. No current application reference remains. It is ready for a separate reviewed archival change only after deployment validation. |
 | `sprint202425` | table | temporary | archive | do-not-map | unknown | `dengueadmin` | none | no runtime evidence found | PK `id`; approx. rows `4187433`; size `655433728` bytes | Time-bounded working table. Maintainers approved archival and no ORM mapping. This PR records lifecycle and ORM decisions only. |
 
 ## Schema `forecast`
@@ -239,7 +239,7 @@ No live objects were found in `forecast`, and no target-schema objects from
 - retention and access policy for `weather.copernicus_bra`
 - write policy for `Municipio.Ovitrampa`
 - handling of the legacy `Ovitrampa.Localidade_id` relationship
-- code removal or replacement required before archiving
+- deployment validation required before separately archiving
   `Municipio.historico_casos`
 - database foreign-key handling required before archiving
   `Municipio.Localidade`
@@ -279,8 +279,8 @@ issue and database change.
 
 Additional constraints:
 
-- `historico_casos` must not be archived until its current application call
-  path is removed or replaced.
+- `historico_casos` must not be archived until the replacement application
+  path has been validated after deployment.
 - `Localidade` must not be archived until the
   `Ovitrampa.Localidade_id` dependency is resolved.
 
@@ -297,7 +297,20 @@ Additional constraints:
   - the legacy `Localidade_id` foreign-key relationship needs an explicitly
     reviewed ORM and database strategy before `Localidade` can be archived
 - `Municipio.historico_casos`
-  - current legacy application call path must be removed or replaced before
-    archival
+  - replacement disease-specific queries require deployment validation before
+    a separate reviewed archival change
 - External consumers not covered by this repository
   - still unverified where relevant
+
+## Related `public` materialized views
+
+These objects are outside the original schema inventory scope. No database
+object is modified by this application-code change.
+
+- `public.city_count_by_uf_dengue_materialized_view`,
+  `public.city_count_by_uf_chik_materialized_view`, and
+  `public.city_count_by_uf_zika_materialized_view` are archival candidates after
+  deployment validation; their application query was replaced by a distinct
+  municipality count from the already-loaded disease-specific state history.
+- `public.epiyear_summary_materialized_view` remains pending external-consumer
+  verification because the public `/api/notif_reduced` endpoint is retained.


### PR DESCRIPTION
### Description:
This PR removes the `NotificationResume` class and decouples the state dashboard from legacy queries.

### Changes

* keeps `/alerta/<state>/<disease>` and `/api/notif_reduced` available;
* replaces `Municipio.historico_casos` with the disease-specific `Historico_alerta*` tables;
* preserves the current monitored-municipality counts on the homepage;
* updates the ORM inventory to mark `historico_casos` for archival after staging validation;
* adds regression tests for the retained routes and queries.

No PostgreSQL objects or data were modified.

Closes #1010
Related to #1008
