### PR TITLE
hotfix(db): allow empty archive lookup fixtures

### DIFF
--- a/containers/postgres/sql_history/archive_schemas_export/restore_archive_schemas_validation.sh
+++ b/containers/postgres/sql_history/archive_schemas_export/restore_archive_schemas_validation.sh
@@ -312,8 +312,8 @@ assert_nonempty_file "${PACKAGE_DIR}/archive_dependencies.tsv"
 assert_nonempty_file "${PACKAGE_DIR}/archive_external_fks.tsv"
 assert_nonempty_file "${PACKAGE_DIR}/archive_internal_fks.tsv"
 assert_nonempty_file "${PACKAGE_DIR}/dengue_archive_schemas.schema.sql"
-assert_nonempty_file "$REGIONAL_KEYS_FILE"
-assert_nonempty_file "$CID10_KEYS_FILE"
+assert_regular_file "$REGIONAL_KEYS_FILE"
+assert_regular_file "$CID10_KEYS_FILE"
 
 tmp_dir="$(mktemp -d)"
 


### PR DESCRIPTION
## Problem

Production archive verification failed because `regional_keys.tsv` was
correctly generated as an empty file.

The three archived regional-alert tables contain zero rows referencing
`Dengue_global.regional`, but the restore validator required the fixture
file to be non-empty.

## Change

Require the regional and CID10 fixture files to:

- exist;
- be regular files;
- not be symbolic links.

Empty fixture files are accepted. Restore and foreign-key validation still
fail when an archive contains references whose lookup keys are missing.

## Production evidence

- `Dengue_global.regional`: 451 rows
- three validated regional foreign keys
- all three archived regional tables: zero referencing rows
- exported dump checksum: PASS
- verification receipt: not generated
- no archive schema removal performed

Related to #1038 