### PR TITLE
chore(db): remove empty infodengue chunked upload table

### DIFF
--- a/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_00_preflight_empty_infodengue_chunked_upload.sql
+++ b/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_00_preflight_empty_infodengue_chunked_upload.sql
@@ -1,0 +1,161 @@
+\set ON_ERROR_STOP on
+\pset pager off
+\if :{?expected_database_name}
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'expected_database_name is required'; END $$;
+\endif
+SELECT current_database() = :'expected_database_name' AS database_name_matches \gset
+\if :database_name_matches
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'connected database does not match expected_database_name'; END $$;
+\endif
+BEGIN;
+SET TRANSACTION READ ONLY;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+SELECT current_database() AS database_name,
+       (SELECT oid FROM pg_database WHERE datname = current_database()) AS database_oid,
+       current_setting('server_version') AS server_version,
+       pg_is_in_recovery() AS in_recovery,
+       current_user AS execution_role;
+
+DO $guard$
+BEGIN
+  IF current_database() <> 'infodengue' THEN
+    RAISE EXCEPTION 'this workflow requires the infodengue database';
+  END IF;
+  IF pg_is_in_recovery() THEN
+    RAISE EXCEPTION 'database is in recovery';
+  END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload') IS NULL THEN
+    RAISE EXCEPTION 'public.chunked_upload_chunkedupload is missing';
+  END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload_id_seq') IS NULL THEN
+    RAISE EXCEPTION 'public.chunked_upload_chunkedupload_id_seq is missing';
+  END IF;
+END $guard$;
+
+SELECT 'public.chunked_upload_chunkedupload' AS table_name,
+       count(*) AS exact_rows,
+       pg_total_relation_size('public.chunked_upload_chunkedupload'::regclass) AS total_bytes
+  FROM public.chunked_upload_chunkedupload;
+
+DO $empty$
+BEGIN
+  IF (SELECT count(*) FROM public.chunked_upload_chunkedupload) <> 0 THEN
+    RAISE EXCEPTION 'public.chunked_upload_chunkedupload contains rows';
+  END IF;
+END $empty$;
+
+SELECT table_name, column_name, ordinal_position, data_type, is_nullable,
+       column_default
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name = 'chunked_upload_chunkedupload'
+ ORDER BY ordinal_position;
+
+SELECT conrelid::regclass AS table_name, conname, contype,
+       pg_get_constraintdef(oid) AS definition, convalidated
+  FROM pg_constraint
+ WHERE conrelid = 'public.chunked_upload_chunkedupload'::regclass
+ ORDER BY conname;
+
+SELECT indrelid::regclass AS table_name, indexrelid::regclass AS index_name,
+       pg_get_indexdef(indexrelid) AS definition
+  FROM pg_index
+ WHERE indrelid = 'public.chunked_upload_chunkedupload'::regclass
+ ORDER BY indexrelid;
+
+SELECT tgrelid::regclass AS table_name, tgname,
+       pg_get_triggerdef(oid) AS definition
+  FROM pg_trigger
+ WHERE tgrelid = 'public.chunked_upload_chunkedupload'::regclass
+   AND NOT tgisinternal
+ ORDER BY tgname;
+
+SELECT schemaname, tablename, rulename, definition
+  FROM pg_rules
+ WHERE schemaname = 'public'
+   AND tablename = 'chunked_upload_chunkedupload'
+ ORDER BY rulename;
+
+SELECT c.oid::regclass AS object_name,
+       pg_get_userbyid(c.relowner) AS owner_name,
+       coalesce(c.relacl::text, '') AS relacl_text,
+       s.last_value,
+       s.is_called,
+       pg_get_serial_sequence('public.chunked_upload_chunkedupload', 'id') AS serial_sequence
+  FROM pg_class c
+  JOIN public.chunked_upload_chunkedupload_id_seq s ON true
+ WHERE c.oid = 'public.chunked_upload_chunkedupload_id_seq'::regclass;
+
+SELECT dep.deptype,
+       seq.oid::regclass AS sequence_name,
+       tbl.oid::regclass AS owning_table,
+       dep.refobjsubid AS owning_column_number,
+       a.attname AS owning_column
+  FROM pg_depend dep
+  JOIN pg_class seq ON seq.oid = dep.objid
+  JOIN pg_class tbl ON tbl.oid = dep.refobjid
+  LEFT JOIN pg_attribute a
+    ON a.attrelid = tbl.oid
+   AND a.attnum = dep.refobjsubid
+ WHERE seq.oid = 'public.chunked_upload_chunkedupload_id_seq'::regclass
+ ORDER BY dep.deptype, dep.refobjsubid;
+
+SELECT d.classid::regclass AS dependency_catalog,
+       d.objid::text AS dependent_object,
+       d.refobjid::regclass AS referenced_object,
+       d.refobjsubid,
+       d.deptype
+  FROM pg_depend d
+ WHERE d.refobjid IN (
+   'public.chunked_upload_chunkedupload'::regclass,
+   'public.chunked_upload_chunkedupload_id_seq'::regclass
+ )
+ ORDER BY 1, 2, 3, 4, 5;
+
+DO $ownership$
+BEGIN
+  IF pg_get_serial_sequence('public.chunked_upload_chunkedupload', 'id') IS DISTINCT FROM 'public.chunked_upload_chunkedupload_id_seq' THEN
+    RAISE EXCEPTION 'owned sequence does not match the table id default';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_depend dep
+     WHERE dep.objid = 'public.chunked_upload_chunkedupload_id_seq'::regclass
+       AND dep.refobjid = 'public.chunked_upload_chunkedupload'::regclass
+       AND dep.refobjsubid = 1
+       AND dep.deptype = 'a'
+  ) THEN
+    RAISE EXCEPTION 'sequence is not owned by public.chunked_upload_chunkedupload.id';
+  END IF;
+END $ownership$;
+
+DO $dependencies$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM pg_constraint con
+     WHERE con.contype = 'f'
+       AND con.confrelid = 'public.chunked_upload_chunkedupload'::regclass
+       AND con.conrelid <> 'public.chunked_upload_chunkedupload'::regclass
+  ) THEN
+    RAISE EXCEPTION 'unexpected inbound foreign-key dependency exists';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+      FROM pg_depend d
+      JOIN pg_rewrite r ON r.oid = d.objid
+     WHERE d.classid = 'pg_rewrite'::regclass
+       AND d.refobjid IN (
+         'public.chunked_upload_chunkedupload'::regclass,
+         'public.chunked_upload_chunkedupload_id_seq'::regclass
+       )
+  ) THEN
+    RAISE EXCEPTION 'unexpected view or rule dependency exists';
+  END IF;
+END $dependencies$;
+
+ROLLBACK;

--- a/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_90_remove_empty_infodengue_chunked_upload.sql
+++ b/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_90_remove_empty_infodengue_chunked_upload.sql
@@ -1,0 +1,84 @@
+\set ON_ERROR_STOP on
+\pset pager off
+\if :{?expected_database_name}
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'expected_database_name is required'; END $$;
+\endif
+\if :{?removal_approval}
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'removal_approval is required'; END $$;
+\endif
+SELECT current_database() = :'expected_database_name' AS database_name_matches \gset
+\if :database_name_matches
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'connected database does not match expected_database_name'; END $$;
+\endif
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+SELECT pg_advisory_xact_lock(hashtext('AlertaDengue.remove_empty_infodengue_chunked_upload'));
+SELECT set_config(
+  'infodengue.empty_chunked_upload_removal_approval',
+  :'removal_approval',
+  true
+);
+
+DO $guard$
+BEGIN
+  IF current_database() <> 'infodengue' THEN
+    RAISE EXCEPTION 'this workflow requires the infodengue database';
+  END IF;
+  IF pg_is_in_recovery() THEN
+    RAISE EXCEPTION 'database is in recovery';
+  END IF;
+  IF current_setting('infodengue.empty_chunked_upload_removal_approval', true) <> 'REMOVE_APPROVED_EMPTY_INFODENGUE_CHUNKED_UPLOAD' THEN
+    RAISE EXCEPTION 'explicit removal approval token is invalid';
+  END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload') IS NULL OR to_regclass('public.chunked_upload_chunkedupload_id_seq') IS NULL THEN
+    RAISE EXCEPTION 'candidate table/sequence inventory is incomplete';
+  END IF;
+  IF (SELECT count(*) FROM public.chunked_upload_chunkedupload) <> 0 THEN
+    RAISE EXCEPTION 'candidate table contains rows';
+  END IF;
+  IF pg_get_serial_sequence('public.chunked_upload_chunkedupload', 'id') IS DISTINCT FROM 'public.chunked_upload_chunkedupload_id_seq' THEN
+    RAISE EXCEPTION 'owned sequence does not match the table id default';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_depend dep
+     WHERE dep.objid = 'public.chunked_upload_chunkedupload_id_seq'::regclass
+       AND dep.refobjid = 'public.chunked_upload_chunkedupload'::regclass
+       AND dep.refobjsubid = 1 AND dep.deptype = 'a'
+  ) THEN RAISE EXCEPTION 'sequence is not owned by candidate table id'; END IF;
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint con
+     WHERE con.contype = 'f'
+       AND con.confrelid = 'public.chunked_upload_chunkedupload'::regclass
+       AND con.conrelid <> 'public.chunked_upload_chunkedupload'::regclass
+  ) THEN RAISE EXCEPTION 'unexpected inbound foreign-key dependency exists'; END IF;
+  IF EXISTS (
+    SELECT 1 FROM pg_depend d JOIN pg_rewrite r ON r.oid = d.objid
+     WHERE d.classid = 'pg_rewrite'::regclass
+       AND d.refobjid IN ('public.chunked_upload_chunkedupload'::regclass, 'public.chunked_upload_chunkedupload_id_seq'::regclass)
+  ) THEN RAISE EXCEPTION 'unexpected view or rule dependency exists'; END IF;
+END $guard$;
+
+SELECT 'PRE-REMOVAL' AS receipt, current_database() AS database_name,
+       clock_timestamp() AT TIME ZONE 'UTC' AS receipt_utc,
+       count(*) AS exact_rows
+  FROM public.chunked_upload_chunkedupload;
+
+DROP TABLE public.chunked_upload_chunkedupload;
+
+DO $post_remove$
+BEGIN
+  IF to_regclass('public.chunked_upload_chunkedupload') IS NOT NULL THEN
+    RAISE EXCEPTION 'candidate table remains after removal';
+  END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload_id_seq') IS NOT NULL THEN
+    RAISE EXCEPTION 'owned sequence remains after table removal';
+  END IF;
+END $post_remove$;
+
+SELECT 'REMOVAL PASS' AS receipt, current_database() AS database_name,
+       clock_timestamp() AT TIME ZONE 'UTC' AS completed_utc;
+COMMIT;

--- a/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_91_validate_empty_infodengue_chunked_upload_removed.sql
+++ b/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/20260806_91_validate_empty_infodengue_chunked_upload_removed.sql
@@ -1,0 +1,64 @@
+\set ON_ERROR_STOP on
+\pset pager off
+\if :{?expected_database_name}
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'expected_database_name is required'; END $$;
+\endif
+SELECT current_database() = :'expected_database_name' AS database_name_matches \gset
+\if :database_name_matches
+\else
+  DO $$ BEGIN RAISE EXCEPTION 'connected database does not match expected_database_name'; END $$;
+\endif
+BEGIN;
+SET TRANSACTION READ ONLY;
+SET LOCAL statement_timeout = '60s';
+
+DO $validate$
+BEGIN
+  IF current_database() <> 'infodengue' THEN RAISE EXCEPTION 'wrong database'; END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload') IS NOT NULL THEN RAISE EXCEPTION 'candidate table remains'; END IF;
+  IF to_regclass('public.chunked_upload_chunkedupload_id_seq') IS NOT NULL THEN RAISE EXCEPTION 'owned sequence remains'; END IF;
+END $validate$;
+
+SELECT object_name, 'absent' AS expected_state,
+       CASE WHEN to_regclass(object_name) IS NULL THEN 'absent' ELSE 'present' END AS actual_state
+  FROM (VALUES
+    ('public.chunked_upload_chunkedupload'::text),
+    ('public.chunked_upload_chunkedupload_id_seq'::text)
+  ) AS candidate(object_name)
+ ORDER BY object_name;
+
+SELECT object_name, 'present' AS expected_state,
+       CASE WHEN to_regclass(object_name) IS NULL THEN 'absent' ELSE 'present' END AS actual_state
+  FROM (VALUES
+    ('public.auth_user'::text),
+    ('public.django_migrations'::text),
+    ('public.django_session'::text),
+    ('public.spatial_ref_sys'::text),
+    ('topology.topology'::text),
+    ('topology.layer'::text)
+  ) AS protected(object_name)
+ ORDER BY object_name;
+
+DO $protected$
+DECLARE
+  protected record;
+BEGIN
+  FOR protected IN
+    SELECT object_name, to_regclass(object_name) AS actual_relation
+      FROM (VALUES
+        ('public.auth_user'::text),
+        ('public.django_migrations'::text),
+        ('public.django_session'::text),
+        ('public.spatial_ref_sys'::text),
+        ('topology.topology'::text),
+        ('topology.layer'::text)
+      ) AS protected_objects(object_name)
+  LOOP
+    IF protected.actual_relation IS NULL THEN
+      RAISE EXCEPTION 'protected object assertion failed: object_name=%, expected_state=present, actual_state=absent', protected.object_name;
+    END IF;
+  END LOOP;
+END $protected$;
+
+ROLLBACK;

--- a/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/README.md
+++ b/containers/postgres/sql_history/remove_empty_infodengue_chunked_upload/README.md
@@ -1,0 +1,88 @@
+# Empty generic chunked-upload table in `infodengue`
+
+This workflow addresses issue #1051 and is exclusively for a development or
+staging `infodengue` database. It removes the reviewed empty generic table and
+its table-owned sequence:
+
+- `public.chunked_upload_chunkedupload`
+- `public.chunked_upload_chunkedupload_id_seq`
+
+The application dependency was retired by the historical upload-app workflow.
+Repository references are limited to historical SQL in
+`containers/postgres/sql_history/upload/` and a tracked notebook’s historical
+table listing. There are no active Django settings, models, routes, tasks,
+management commands, tests, container scripts, migrations, or bootstrap/schema
+references for this app/table.
+
+## Safety
+
+Use only a reviewed development/staging connection. Never use a production
+connection. Configure libpq credentials outside the repository:
+
+```bash
+SQL_DIR=containers/postgres/sql_history/remove_empty_infodengue_chunked_upload
+PSQL=(psql -X -v ON_ERROR_STOP=1)
+```
+
+The preflight and validator are read-only transactions ending with `ROLLBACK`.
+The removal script requires the exact database name, an explicit approval
+token, an advisory transaction lock, a zero-row recheck, dependency checks, and
+proof that the sequence is owned by the target table’s `id` column. It drops
+only the one named table and relies on PostgreSQL’s ownership dependency to
+remove the owned sequence.
+
+## Step 1 — Read-only preflight
+
+```bash
+"${PSQL[@]}" -v expected_database_name=infodengue \
+  -f "${SQL_DIR}/20260806_00_preflight_empty_infodengue_chunked_upload.sql"
+```
+
+Review the exact row count, size, columns, constraints, indexes, triggers,
+rules, sequence owner/state, ownership dependency, and dependency inventory.
+The script must finish with `ROLLBACK`. Any row or unexpected inbound
+foreign-key/view/rule dependency is a hard failure.
+
+## Step 2 — Explicit removal after review
+
+Do not run removal as part of ordinary validation. After separate review and
+development/staging confirmation, invoke it with the exact token:
+
+```bash
+"${PSQL[@]}" \
+  -v expected_database_name=infodengue \
+  -v removal_approval=REMOVE_APPROVED_EMPTY_INFODENGUE_CHUNKED_UPLOAD \
+  -f "${SQL_DIR}/20260806_90_remove_empty_infodengue_chunked_upload.sql"
+```
+
+The transaction commits only after the table and owned sequence are absent.
+Retain the command output as the removal receipt. No separate sequence drop is
+issued.
+
+## Step 3 — Read-only post-removal validation
+
+```bash
+"${PSQL[@]}" -v expected_database_name=infodengue \
+  -f "${SQL_DIR}/20260806_91_validate_empty_infodengue_chunked_upload_removed.sql"
+```
+
+The validator must finish with `ROLLBACK`, confirm both target objects are
+absent, and confirm these protected objects remain:
+
+- `public.auth_user`
+- `public.django_migrations`
+- `public.django_session`
+- `public.spatial_ref_sys`
+- `topology.topology`
+- `topology.layer`
+
+DBF objects and historical `Dengue_*` objects are intentionally not required;
+they belong to separate cleanup issues.
+
+## Current evidence and checks
+
+The reviewed development/staging audit found exact row count zero. The generic
+table is not in the current `schemas_infodengue.sql`; its old upload-app SQL
+history is retained as historical evidence and is not bootstrap input. No live
+preflight was run while preparing this package because no local PostgreSQL
+endpoint was available. Removal is not authorized by this commit.


### PR DESCRIPTION
## Description

Implements the guarded cleanup workflow for issue #1051: remove the empty generic chunked upload table from the `infodengue` database.

Target objects:

```sql
public.chunked_upload_chunkedupload
public.chunked_upload_chunkedupload_id_seq``` 