### PR TITLE
refactor(api): introduce historical alert service layer

### DIFF
--- a/AlertaDengue/api/internal/historical_alerts.py
+++ b/AlertaDengue/api/internal/historical_alerts.py
@@ -1,0 +1,169 @@
+"""Bounded ORM access to the retained historical-alert tables.
+
+The three legacy tables remain separate and unmanaged.  This module provides
+the normalized interface intended for future internal REST endpoints.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from django.db.models import Model, QuerySet
+
+from dados.services.historical_alerts import (
+    get_legacy_historical_alert_model,
+    normalize_disease_key,
+)
+
+DEFAULT_HISTORICAL_ALERT_LIMIT = 1000
+MAX_HISTORICAL_ALERT_LIMIT = 5000
+
+_ORDERING_FIELDS = frozenset(
+    {
+        "alert_level",
+        "epidemiological_week",
+        "epidemiological_week_start_date",
+        "estimated_cases",
+        "municipality_geocode",
+    }
+)
+_RESPONSE_FIELDS = (
+    "disease",
+    "municipality_geocode",
+    "municipality_name",
+    "epidemiological_week",
+    "epidemiological_week_start_date",
+    "estimated_cases",
+    "estimated_cases_min",
+    "estimated_cases_max",
+    "cases",
+    "probable_cases",
+    "confirmed_cases",
+    "alert_level",
+    "model_version",
+    "rt1_probability",
+    "incidence_100k_probability",
+)
+
+
+@dataclass(frozen=True)
+class HistoricalAlertFilters:
+    """Validated filters for a bounded historical-alert query.
+
+    Parameters
+    ----------
+    disease
+        Dengue, chik/chikungunya, or zika.
+    """
+
+    disease: str
+    municipality_geocode: int | None = None
+    epidemiological_week: int | None = None
+    start_week: int | None = None
+    end_week: int | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    alert_level: int | None = None
+    limit: int = DEFAULT_HISTORICAL_ALERT_LIMIT
+    offset: int = 0
+    ordering: str = "-epidemiological_week"
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the supplied service-layer inputs."""
+        object.__setattr__(
+            self, "disease", normalize_disease_key(self.disease)
+        )
+
+        if self.start_week is not None and self.end_week is not None:
+            if self.start_week > self.end_week:
+                raise ValueError("start_week cannot be greater than end_week")
+        if self.start_date is not None and self.end_date is not None:
+            if self.start_date > self.end_date:
+                raise ValueError("start_date cannot be greater than end_date")
+        if self.limit < 0:
+            raise ValueError("limit cannot be negative")
+        if self.limit > MAX_HISTORICAL_ALERT_LIMIT:
+            raise ValueError(
+                f"limit cannot exceed {MAX_HISTORICAL_ALERT_LIMIT}"
+            )
+        if self.offset < 0:
+            raise ValueError("offset cannot be negative")
+        if self.ordering.lstrip("-") not in _ORDERING_FIELDS:
+            raise ValueError("unsupported historical-alert ordering field")
+
+
+def build_historical_alert_queryset(
+    filters: HistoricalAlertFilters,
+) -> QuerySet:
+    """Build a bounded, unevaluated QuerySet for historical alerts.
+
+    The model selection is delegated to the retained #1063 adapter helper,
+    so callers never route to legacy table names directly.
+    """
+    model = get_legacy_historical_alert_model(filters.disease)
+    queryset = model.objects.all()
+
+    if filters.municipality_geocode is not None:
+        queryset = queryset.filter(
+            municipality_geocode=filters.municipality_geocode
+        )
+    if filters.epidemiological_week is not None:
+        queryset = queryset.filter(
+            epidemiological_week=filters.epidemiological_week
+        )
+    if filters.start_week is not None:
+        queryset = queryset.filter(
+            epidemiological_week__gte=filters.start_week
+        )
+    if filters.end_week is not None:
+        queryset = queryset.filter(epidemiological_week__lte=filters.end_week)
+    if filters.start_date is not None:
+        queryset = queryset.filter(
+            epidemiological_week_start_date__gte=filters.start_date
+        )
+    if filters.end_date is not None:
+        queryset = queryset.filter(
+            epidemiological_week_start_date__lte=filters.end_date
+        )
+    if filters.alert_level is not None:
+        queryset = queryset.filter(alert_level=filters.alert_level)
+
+    return queryset.order_by(filters.ordering)[
+        filters.offset : filters.offset + filters.limit
+    ]
+
+
+def get_historical_alert_queryset(
+    disease: str,
+    **filters: Any,
+) -> QuerySet:
+    """Construct a bounded historical-alert QuerySet from API-ready inputs."""
+    return build_historical_alert_queryset(
+        HistoricalAlertFilters(disease=disease, **filters)
+    )
+
+
+def get_historical_alert_response_fields() -> tuple[str, ...]:
+    """Return the normalized field names exposed by this service."""
+    return _RESPONSE_FIELDS
+
+
+def serialize_historical_alert(
+    record: Model | Mapping[str, Any], disease: str
+) -> dict[str, Any]:
+    """Serialize an alert model instance or mapping with normalized keys."""
+    normalized_disease = normalize_disease_key(disease)
+    serialized = {"disease": normalized_disease}
+    for field in _RESPONSE_FIELDS[1:]:
+        value = (
+            record.get(field)
+            if isinstance(record, Mapping)
+            else getattr(record, field, None)
+        )
+        serialized[field] = (
+            value.isoformat() if isinstance(value, (date, datetime)) else value
+        )
+    return serialized

--- a/AlertaDengue/tests/api/test_historical_alert_service.py
+++ b/AlertaDengue/tests/api/test_historical_alert_service.py
@@ -1,0 +1,116 @@
+from datetime import date
+
+import pytest
+
+from api.internal.historical_alerts import (
+    DEFAULT_HISTORICAL_ALERT_LIMIT,
+    HistoricalAlertFilters,
+    build_historical_alert_queryset,
+    get_historical_alert_queryset,
+    get_historical_alert_response_fields,
+    serialize_historical_alert,
+)
+from dados.models import (
+    LegacyHistoricalAlertChikungunya,
+    LegacyHistoricalAlertDengue,
+    LegacyHistoricalAlertZika,
+)
+from dados.services.historical_alerts import get_legacy_historical_alert_model
+
+
+@pytest.mark.parametrize(
+    ("disease", "model"),
+    [
+        ("dengue", LegacyHistoricalAlertDengue),
+        ("chik", LegacyHistoricalAlertChikungunya),
+        ("chikungunya", LegacyHistoricalAlertChikungunya),
+        ("zika", LegacyHistoricalAlertZika),
+    ],
+)
+def test_historical_alert_disease_routing(disease, model):
+    assert get_legacy_historical_alert_model(disease) is model
+    queryset = build_historical_alert_queryset(HistoricalAlertFilters(disease))
+    assert queryset.model is model
+
+
+def test_historical_alert_service_rejects_unknown_disease():
+    with pytest.raises(ValueError, match="supported values"):
+        HistoricalAlertFilters("yellow-fever")
+
+
+def test_historical_alert_queryset_uses_normalized_filters_and_table():
+    queryset = get_historical_alert_queryset(
+        "dengue",
+        municipality_geocode=3304557,
+        epidemiological_week=202601,
+    )
+
+    sql = str(queryset.query)
+
+    assert queryset.model is LegacyHistoricalAlertDengue
+    assert '"Municipio"."Historico_alerta"' in sql
+    assert '"municipio_geocodigo"' in sql
+    assert '"SE"' in sql
+    assert f"LIMIT {DEFAULT_HISTORICAL_ALERT_LIMIT}" in sql
+
+
+def test_historical_alert_range_filters_and_ordering_are_applied():
+    queryset = get_historical_alert_queryset(
+        "zika",
+        start_week=202601,
+        end_week=202652,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        ordering="epidemiological_week",
+    )
+    sql = str(queryset.query)
+
+    assert queryset.model is LegacyHistoricalAlertZika
+    assert '"SE" >=' in sql
+    assert '"SE" <=' in sql
+    assert '"data_iniSE" >=' in sql
+    assert '"data_iniSE" <=' in sql
+    assert '"SE" ASC' in sql
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"start_week": 202652, "end_week": 202601},
+        {"start_date": date(2026, 2, 1), "end_date": date(2026, 1, 1)},
+        {"limit": -1},
+        {"limit": 5001},
+        {"offset": -1},
+        {"ordering": "municipality_geocode; DROP TABLE alerts"},
+    ],
+)
+def test_historical_alert_service_rejects_unsafe_filters(filters):
+    with pytest.raises(ValueError):
+        HistoricalAlertFilters("dengue", **filters)
+
+
+def test_historical_alert_serialization_uses_normalized_response_fields():
+    record = LegacyHistoricalAlertDengue(
+        municipality_geocode=3304557,
+        municipality_name="Rio de Janeiro",
+        epidemiological_week=202601,
+        epidemiological_week_start_date=date(2026, 1, 4),
+        estimated_cases=12.5,
+        probable_cases=11,
+    )
+
+    serialized = serialize_historical_alert(record, "chik")
+
+    assert serialized["disease"] == "chikungunya"
+    assert serialized["epidemiological_week_start_date"] == "2026-01-04"
+    assert set(serialized) == set(get_historical_alert_response_fields())
+    for legacy_key in (
+        "SE",
+        "data_iniSE",
+        "Localidade_id",
+        "municipio_geocodigo",
+        "casos_est",
+        "p_rt1",
+        "p_inc100k",
+    ):
+        assert legacy_key not in serialized

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -1,0 +1,13 @@
+# Historical alert service layer
+
+Issue #1064 adds an internal REST/API service layer for historical alerts in
+`api.internal.historical_alerts`. It reuses the #1063 unmanaged ORM adapters
+and hides legacy table routing behind normalized Python-facing functions.
+
+The API-facing fields use English `snake_case`. The retained
+`Historico_alerta`, `Historico_alerta_chik`, and `Historico_alerta_zika` tables
+remain separate and unmanaged. The #1042 physical merge remains deferred.
+
+The service deliberately leaves dashboard and report raw SQL unchanged until
+those paths are benchmarked. It introduces no migrations, production database
+connections, SQL writes, or physical database changes.


### PR DESCRIPTION
Description:


This PR introduces an internal historical-alert service layer on top of the unmanaged ORM adapters added in #1063.

Implemented #1064:

- `api.internal.historical_alerts`;
- bounded historical-alert QuerySet construction;
- validated `HistoricalAlertFilters`;
- normalized disease routing for dengue, chikungunya and zika;
- allowlisted ordering;
- limit/offset safety;
- normalized serialization fields;
- focused tests for routing, filters, SQL table selection, unsafe inputs and serialization;
- service documentation.

The three `Historico_alerta*` tables remain separate and unmanaged. No #1042 physical merge was implemented.
- Closes #1064 

Validation:

- pre-commit on touched Python files;
- `python -m compileall AlertaDengue/api AlertaDengue/dados`;
- `python AlertaDengue/manage.py check`;
- `python AlertaDengue/manage.py makemigrations --check --dry-run`;
- `git diff --check`;
- focused pytest suite: 33 passed.

No migration, production connection, SQL write, migration apply, physical database change, REST endpoint, or raw-SQL replacement was made.