### PR TITLE
feat(api): expose internal historical alert endpoint

### DIFF
--- a/AlertaDengue/api/internal/permissions.py
+++ b/AlertaDengue/api/internal/permissions.py
@@ -19,3 +19,9 @@ class HasNotificationAPIAccess(BasePermission):
             return True
 
         return user.groups.filter(name=NOTIFICATION_API_GROUP_NAME).exists()
+
+
+class HasInternalAPIAccess(HasNotificationAPIAccess):
+    """Backward-compatible token/group access for internal API endpoints."""
+
+    message = "User does not have access to the internal API."

--- a/AlertaDengue/api/internal/urls.py
+++ b/AlertaDengue/api/internal/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from api.internal.views import NotificationListView
+from api.internal.views import HistoricalAlertListView, NotificationListView
 
 app_name = "internal"
 
@@ -9,5 +9,10 @@ urlpatterns = [
         "notifications/",
         NotificationListView.as_view(),
         name="notifications",
+    ),
+    path(
+        "historical-alerts/",
+        HistoricalAlertListView.as_view(),
+        name="historical_alerts",
     ),
 ]

--- a/AlertaDengue/api/internal/views.py
+++ b/AlertaDengue/api/internal/views.py
@@ -1,8 +1,18 @@
+from datetime import date
+from typing import Any
+
 from django.db import DatabaseError
 from pydantic import ValidationError
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from api.internal.historical_alerts import (
+    HistoricalAlertFilters,
+    get_historical_alert_queryset,
+    get_historical_alert_response_fields,
+    serialize_historical_alert,
+)
 from api.internal.permissions import HasNotificationAPIAccess
 from api.internal.services import list_notifications
 
@@ -22,3 +32,63 @@ class NotificationListView(APIView):
             )
 
         return Response(payload)
+
+
+class HistoricalAlertListView(APIView):
+    """Return bounded, normalized historical-alert records."""
+
+    permission_classes = [AllowAny]
+    _INTEGER_PARAMS = (
+        "municipality_geocode",
+        "epidemiological_week",
+        "start_week",
+        "end_week",
+        "alert_level",
+        "limit",
+        "offset",
+    )
+    _DATE_PARAMS = ("start_date", "end_date")
+
+    def get(self, request):
+        try:
+            disease = request.query_params.get("disease")
+            if not disease:
+                raise ValueError("disease is required")
+
+            query_params = self._parse_query_params(request.query_params)
+            filters = HistoricalAlertFilters(disease, **query_params)
+            queryset = get_historical_alert_queryset(
+                filters.disease,
+                **query_params,
+            )
+            results = [
+                self._serialize_record(record, filters.disease)
+                for record in queryset
+            ]
+        except (TypeError, ValueError) as exc:
+            return Response({"detail": str(exc)}, status=400)
+
+        return Response({"count": len(results), "results": results})
+
+    @classmethod
+    def _parse_query_params(cls, query_params):
+        """Convert supported string parameters to service-layer types."""
+        parsed: dict[str, Any] = {}
+        for parameter in cls._INTEGER_PARAMS:
+            if parameter in query_params:
+                parsed[parameter] = int(query_params[parameter])
+        for parameter in cls._DATE_PARAMS:
+            if parameter in query_params:
+                parsed[parameter] = date.fromisoformat(query_params[parameter])
+        if "ordering" in query_params:
+            parsed["ordering"] = query_params["ordering"]
+        return parsed
+
+    @staticmethod
+    def _serialize_record(record, disease):
+        """Serialize one record using only service-declared response fields."""
+        serialized = serialize_historical_alert(record, disease)
+        return {
+            field: serialized[field]
+            for field in get_historical_alert_response_fields()
+        }

--- a/AlertaDengue/api/internal/views.py
+++ b/AlertaDengue/api/internal/views.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from django.db import DatabaseError
 from pydantic import ValidationError
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,7 +12,10 @@ from api.internal.historical_alerts import (
     get_historical_alert_response_fields,
     serialize_historical_alert,
 )
-from api.internal.permissions import HasNotificationAPIAccess
+from api.internal.permissions import (
+    HasInternalAPIAccess,
+    HasNotificationAPIAccess,
+)
 from api.internal.services import list_notifications
 
 
@@ -37,7 +39,7 @@ class NotificationListView(APIView):
 class HistoricalAlertListView(APIView):
     """Return bounded, normalized historical-alert records."""
 
-    permission_classes = [AllowAny]
+    permission_classes = [HasInternalAPIAccess]
     _INTEGER_PARAMS = (
         "municipality_geocode",
         "epidemiological_week",

--- a/AlertaDengue/api/urls.py
+++ b/AlertaDengue/api/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path, re_path
 
+from .internal.views import HistoricalAlertListView
 from .views import AlertCityView, EpiYearWeekView, NotificationReducedCSV_View
 
 app_name = "api"
@@ -15,6 +16,11 @@ urlpatterns = [
         r"^epi_year_week$",
         EpiYearWeekView.as_view(),
         name="epi_year_week",
+    ),
+    path(
+        "historical-alerts/",
+        HistoricalAlertListView.as_view(),
+        name="historical_alerts",
     ),
     path("internal/", include("api.internal.urls")),
 ]

--- a/AlertaDengue/api/urls.py
+++ b/AlertaDengue/api/urls.py
@@ -1,6 +1,5 @@
 from django.urls import include, path, re_path
 
-from .internal.views import HistoricalAlertListView
 from .views import AlertCityView, EpiYearWeekView, NotificationReducedCSV_View
 
 app_name = "api"
@@ -16,11 +15,6 @@ urlpatterns = [
         r"^epi_year_week$",
         EpiYearWeekView.as_view(),
         name="epi_year_week",
-    ),
-    path(
-        "historical-alerts/",
-        HistoricalAlertListView.as_view(),
-        name="historical_alerts",
     ),
     path("internal/", include("api.internal.urls")),
 ]

--- a/AlertaDengue/tests/api/test_historical_alert_endpoint.py
+++ b/AlertaDengue/tests/api/test_historical_alert_endpoint.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import MagicMock
 
 from django.db.models import QuerySet
 from django.urls import reverse
@@ -13,6 +14,18 @@ from dados.models import LegacyHistoricalAlertDengue
 def api_client():
     """Return the current REST API test client."""
     return APIClient()
+
+
+@pytest.fixture()
+def internal_api_client(api_client):
+    """Return a client allowed by the existing internal group permission."""
+    user = MagicMock()
+    user.is_authenticated = True
+    user.is_active = True
+    user.is_superuser = False
+    user.groups.filter.return_value.exists.return_value = True
+    api_client.force_authenticate(user=user)
+    return api_client
 
 
 @pytest.fixture()
@@ -48,13 +61,13 @@ def bounded_queryset(monkeypatch, historical_alert_record):
     ],
 )
 def test_historical_alert_endpoint_returns_normalized_records(
-    api_client,
+    internal_api_client,
     bounded_queryset,
     disease,
     expected_disease,
 ):
-    response = api_client.get(
-        reverse("api:historical_alerts"),
+    response = internal_api_client.get(
+        reverse("api:internal:historical_alerts"),
         {"disease": disease},
     )
 
@@ -70,7 +83,7 @@ def test_historical_alert_endpoint_returns_normalized_records(
 
 
 def test_historical_alert_endpoint_passes_typed_inputs_to_real_service(
-    api_client,
+    internal_api_client,
     bounded_queryset,
     monkeypatch,
 ):
@@ -86,8 +99,8 @@ def test_historical_alert_endpoint_passes_typed_inputs_to_real_service(
         views, "get_historical_alert_queryset", spy_get_queryset
     )
 
-    response = api_client.get(
-        reverse("api:historical_alerts"),
+    response = internal_api_client.get(
+        reverse("api:internal:historical_alerts"),
         {
             "disease": "dengue",
             "municipality_geocode": "3304557",
@@ -139,19 +152,23 @@ def test_historical_alert_endpoint_passes_typed_inputs_to_real_service(
         {"disease": "dengue", "offset": "-1"},
     ],
 )
-def test_historical_alert_endpoint_rejects_invalid_input(api_client, params):
-    response = api_client.get(reverse("api:historical_alerts"), params)
+def test_historical_alert_endpoint_rejects_invalid_input(
+    internal_api_client, params
+):
+    response = internal_api_client.get(
+        reverse("api:internal:historical_alerts"), params
+    )
 
     assert response.status_code == 400
     assert "detail" in response.json()
 
 
 def test_historical_alert_endpoint_never_exposes_legacy_keys(
-    api_client,
+    internal_api_client,
     bounded_queryset,
 ):
-    response = api_client.get(
-        reverse("api:historical_alerts"),
+    response = internal_api_client.get(
+        reverse("api:internal:historical_alerts"),
         {"disease": "dengue"},
     )
 
@@ -166,3 +183,12 @@ def test_historical_alert_endpoint_never_exposes_legacy_keys(
         "p_inc100k",
     ):
         assert legacy_key not in result
+
+
+def test_historical_alert_endpoint_requires_internal_token(api_client):
+    response = api_client.get(
+        reverse("api:internal:historical_alerts"),
+        {"disease": "dengue"},
+    )
+
+    assert response.status_code in {401, 403}

--- a/AlertaDengue/tests/api/test_historical_alert_endpoint.py
+++ b/AlertaDengue/tests/api/test_historical_alert_endpoint.py
@@ -1,0 +1,168 @@
+from datetime import date
+
+from django.db.models import QuerySet
+from django.urls import reverse
+import pytest
+from rest_framework.test import APIClient
+
+from api.internal import views
+from dados.models import LegacyHistoricalAlertDengue
+
+
+@pytest.fixture()
+def api_client():
+    """Return the current REST API test client."""
+    return APIClient()
+
+
+@pytest.fixture()
+def historical_alert_record():
+    """Return an unsaved historical alert for serialization tests."""
+    return LegacyHistoricalAlertDengue(
+        municipality_geocode=3304557,
+        municipality_name="Rio de Janeiro",
+        epidemiological_week=202601,
+        epidemiological_week_start_date=date(2026, 1, 4),
+        estimated_cases=12.5,
+        probable_cases=11,
+    )
+
+
+@pytest.fixture()
+def bounded_queryset(monkeypatch, historical_alert_record):
+    """Keep endpoint tests at the bounded QuerySet evaluation boundary."""
+    monkeypatch.setattr(
+        QuerySet,
+        "__iter__",
+        lambda _queryset: iter([historical_alert_record]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("disease", "expected_disease"),
+    [
+        ("dengue", "dengue"),
+        ("chik", "chikungunya"),
+        ("chikungunya", "chikungunya"),
+        ("zika", "zika"),
+    ],
+)
+def test_historical_alert_endpoint_returns_normalized_records(
+    api_client,
+    bounded_queryset,
+    disease,
+    expected_disease,
+):
+    response = api_client.get(
+        reverse("api:historical_alerts"),
+        {"disease": disease},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["results"][0]["disease"] == expected_disease
+    assert payload["results"][0]["municipality_geocode"] == 3304557
+    assert (
+        payload["results"][0]["epidemiological_week_start_date"]
+        == "2026-01-04"
+    )
+
+
+def test_historical_alert_endpoint_passes_typed_inputs_to_real_service(
+    api_client,
+    bounded_queryset,
+    monkeypatch,
+):
+    captured = {}
+    real_get_queryset = views.get_historical_alert_queryset
+
+    def spy_get_queryset(disease, **filters):
+        captured["disease"] = disease
+        captured["filters"] = filters
+        return real_get_queryset(disease, **filters)
+
+    monkeypatch.setattr(
+        views, "get_historical_alert_queryset", spy_get_queryset
+    )
+
+    response = api_client.get(
+        reverse("api:historical_alerts"),
+        {
+            "disease": "dengue",
+            "municipality_geocode": "3304557",
+            "epidemiological_week": "202601",
+            "start_week": "202601",
+            "end_week": "202652",
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "alert_level": "2",
+            "limit": "10",
+            "offset": "3",
+            "ordering": "epidemiological_week",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "disease": "dengue",
+        "filters": {
+            "municipality_geocode": 3304557,
+            "epidemiological_week": 202601,
+            "start_week": 202601,
+            "end_week": 202652,
+            "start_date": date(2026, 1, 1),
+            "end_date": date(2026, 12, 31),
+            "alert_level": 2,
+            "limit": 10,
+            "offset": 3,
+            "ordering": "epidemiological_week",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"disease": "yellow-fever"},
+        {"disease": "dengue", "municipality_geocode": "not-an-int"},
+        {"disease": "dengue", "start_date": "2026-99-99"},
+        {"disease": "dengue", "start_week": "202652", "end_week": "202601"},
+        {
+            "disease": "dengue",
+            "start_date": "2026-02-01",
+            "end_date": "2026-01-01",
+        },
+        {"disease": "dengue", "ordering": "id; DROP TABLE alerts"},
+        {"disease": "dengue", "limit": "-1"},
+        {"disease": "dengue", "offset": "-1"},
+    ],
+)
+def test_historical_alert_endpoint_rejects_invalid_input(api_client, params):
+    response = api_client.get(reverse("api:historical_alerts"), params)
+
+    assert response.status_code == 400
+    assert "detail" in response.json()
+
+
+def test_historical_alert_endpoint_never_exposes_legacy_keys(
+    api_client,
+    bounded_queryset,
+):
+    response = api_client.get(
+        reverse("api:historical_alerts"),
+        {"disease": "dengue"},
+    )
+
+    result = response.json()["results"][0]
+    for legacy_key in (
+        "SE",
+        "data_iniSE",
+        "Localidade_id",
+        "municipio_geocodigo",
+        "casos_est",
+        "p_rt1",
+        "p_inc100k",
+    ):
+        assert legacy_key not in result

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -4,11 +4,13 @@ Issue #1064 adds an internal REST/API service layer for historical alerts in
 `api.internal.historical_alerts`. It reuses the #1063 unmanaged ORM adapters
 and hides legacy table routing behind normalized Python-facing functions.
 
-Issue #1066 exposes that service at `GET /api/historical-alerts/`. It accepts
-the required `disease` parameter (`dengue`, `chik`, `chikungunya`, or `zika`)
-and optional `municipality_geocode`, `epidemiological_week`, `start_week`,
-`end_week`, `start_date`, `end_date`, `alert_level`, `limit`, `offset`, and
-allowlisted `ordering`. Invalid or unsafe input returns HTTP 400.
+Issue #1066 exposes that service as the restricted internal endpoint
+`GET /api/internal/historical-alerts/`. It uses the existing token/group API
+permission and accepts the required `disease` parameter (`dengue`, `chik`,
+`chikungunya`, or `zika`) and optional `municipality_geocode`,
+`epidemiological_week`, `start_week`, `end_week`, `start_date`, `end_date`,
+`alert_level`, `limit`, `offset`, and allowlisted `ordering`. Invalid or unsafe
+input returns HTTP 400 for authorized requests.
 
 Responses have a bounded `count` and `results` list. Each result is serialized
 by the service layer with normalized English `snake_case` fields only.

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -4,6 +4,22 @@ Issue #1064 adds an internal REST/API service layer for historical alerts in
 `api.internal.historical_alerts`. It reuses the #1063 unmanaged ORM adapters
 and hides legacy table routing behind normalized Python-facing functions.
 
+Issue #1066 exposes that service at `GET /api/historical-alerts/`. It accepts
+the required `disease` parameter (`dengue`, `chik`, `chikungunya`, or `zika`)
+and optional `municipality_geocode`, `epidemiological_week`, `start_week`,
+`end_week`, `start_date`, `end_date`, `alert_level`, `limit`, `offset`, and
+allowlisted `ordering`. Invalid or unsafe input returns HTTP 400.
+
+Responses have a bounded `count` and `results` list. Each result is serialized
+by the service layer with normalized English `snake_case` fields only.
+
+```json
+{
+  "count": 1,
+  "results": [{"disease": "dengue", "municipality_geocode": 3304557}]
+}
+```
+
 The API-facing fields use English `snake_case`. The retained
 `Historico_alerta`, `Historico_alerta_chik`, and `Historico_alerta_zika` tables
 remain separate and unmanaged. The #1042 physical merge remains deferred.

--- a/docs/api/rest_api_architecture.md
+++ b/docs/api/rest_api_architecture.md
@@ -1,0 +1,26 @@
+# REST API architecture
+
+## Legacy public API
+
+Existing non-REST public endpoints remain in their current modules and routes
+for backward compatibility. They are not refactored as part of the REST work.
+
+## Public REST API
+
+A future public REST contract should use a versioned route such as `/api/v1/`.
+Public data may use `AllowAny` where appropriate. No public REST endpoint is
+implemented by this architecture document.
+
+## Internal REST API
+
+Restricted endpoints for analysts, tools, and controlled external integrations
+live under `/api/internal/`. They use the existing token/group API permission.
+Internal services and views may live under `api.internal.*`; public REST
+endpoints should not.
+
+## Naming
+
+Python modules, functions, and variables use `lower_snake_case`; Django
+classes use `PascalCase`; and response fields use normalized English
+`snake_case`. Future database identifiers use lowercase `snake_case`. Legacy
+database identifiers remain confined to adapter or service internals.


### PR DESCRIPTION
### Description:

This PR exposes the historical alert service layer through a restricted internal REST endpoint:

`GET /api/internal/historical-alerts/`

Implemented and closes #1066:

- internal endpoint for bounded historical alert queries;
- `HasInternalAPIAccess` as a generic internal API permission alias over the existing token/group access behavior;
- normalized response fields using the historical alert service layer;
- validation for disease, ranges, dates, limits, offsets and ordering;
- internal API route wiring;
- endpoint tests for restricted access, authorized requests, parsing, validation, response shape and service integration;
- REST API architecture documentation.

The endpoint keeps the three `Historico_alerta*` tables separate and unmanaged. No #1042 physical merge was implemented.

Validation:

- pre-commit hooks, including Ruff, MyPy and Bandit;
- Django check and compilation;
- `makemigrations --check --dry-run`: no changes detected;
- historical endpoint/service/adapter tests: 49 passed;
- existing notification token/group authorization tests: 13 passed.

No migration, production connection, migration apply, application SQL write, physical database change, raw-SQL replacement, or public `/api/v1/` endpoint was introduced.