### PR TITLE
refactor(api): define public REST v1 structure

### DIFF
--- a/AlertaDengue/api/urls.py
+++ b/AlertaDengue/api/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
         EpiYearWeekView.as_view(),
         name="epi_year_week",
     ),
+    path("v1/", include("api.v1.urls")),
     path("internal/", include("api.internal.urls")),
 ]

--- a/AlertaDengue/api/v1/__init__.py
+++ b/AlertaDengue/api/v1/__init__.py
@@ -1,0 +1,1 @@
+"""Public, versioned REST API package."""

--- a/AlertaDengue/api/v1/responses.py
+++ b/AlertaDengue/api/v1/responses.py
@@ -1,0 +1,27 @@
+"""Small response-payload helpers for public REST API endpoints."""
+
+from typing import Any
+
+
+def build_success_response(
+    data: Any = None,
+    *,
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable public success payload."""
+    payload = {"data": data}
+    if meta is not None:
+        payload["meta"] = meta
+    return payload
+
+
+def build_error_response(
+    detail: str,
+    *,
+    code: str | None = None,
+) -> dict[str, str]:
+    """Build a stable public error payload."""
+    payload = {"detail": detail}
+    if code is not None:
+        payload["code"] = code
+    return payload

--- a/AlertaDengue/api/v1/urls.py
+++ b/AlertaDengue/api/v1/urls.py
@@ -2,8 +2,24 @@
 
 from django.urls import path
 
-from api.v1.views import PublicAPIRootView
+from api.v1.views import (
+    PublicAlertCityView,
+    PublicAPIRootView,
+    PublicEpiYearWeekView,
+    PublicNotificationReducedCSVView,
+)
 
 app_name = "v1"
 
-urlpatterns = [path("", PublicAPIRootView.as_view(), name="root")]
+urlpatterns = [
+    path("", PublicAPIRootView.as_view(), name="root"),
+    path("alert-city/", PublicAlertCityView.as_view(), name="alert_city"),
+    path(
+        "epi-year-week/", PublicEpiYearWeekView.as_view(), name="epi_year_week"
+    ),
+    path(
+        "notifications/reduced.csv",
+        PublicNotificationReducedCSVView.as_view(),
+        name="notification_reduced_csv",
+    ),
+]

--- a/AlertaDengue/api/v1/urls.py
+++ b/AlertaDengue/api/v1/urls.py
@@ -1,0 +1,9 @@
+"""Routing for the public REST API v1 surface."""
+
+from django.urls import path
+
+from api.v1.views import PublicAPIRootView
+
+app_name = "v1"
+
+urlpatterns = [path("", PublicAPIRootView.as_view(), name="root")]

--- a/AlertaDengue/api/v1/views.py
+++ b/AlertaDengue/api/v1/views.py
@@ -1,8 +1,15 @@
 """Views for the public REST API v1 surface."""
 
+from datetime import datetime
+
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from api.db import AlertCity
+from api.v1.responses import build_error_response, build_success_response
+from api.views import NotificationReducedCSV_View
+from dados.episem import episem
 
 
 class PublicAPIRootView(APIView):
@@ -20,3 +27,71 @@ class PublicAPIRootView(APIView):
                 "routes": {},
             }
         )
+
+
+class PublicAlertCityView(APIView):
+    """Return normalized city-alert records through the legacy query service."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        try:
+            disease = request.query_params["disease"].lower()
+            geocode = int(request.query_params["geocode"])
+            ew_start = request.query_params.get("ew_start")
+            ew_end = request.query_params.get("ew_end")
+            records = AlertCity.search(
+                disease,
+                geocode,
+                int(ew_start) if ew_start else None,
+                int(ew_end) if ew_end else None,
+            ).rename(
+                columns={
+                    "SE": "epidemiological_week",
+                    "data_iniSE": "epidemiological_week_start_date",
+                    "municipio_geocodigo": "municipality_geocode",
+                    "casos": "cases",
+                    "nivel": "alert_level",
+                }
+            )
+        except (KeyError, ValueError) as exc:
+            return Response(
+                build_error_response(str(exc), code="invalid_query"),
+                status=400,
+            )
+
+        return Response(build_success_response(records.to_dict("records")))
+
+
+class PublicEpiYearWeekView(APIView):
+    """Return a normalized epidemiological year/week response."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        try:
+            epidate = datetime.strptime(
+                request.query_params["epidate"], "%Y-%m-%d"
+            )
+        except (KeyError, ValueError) as exc:
+            return Response(
+                build_error_response(str(exc), code="invalid_query"),
+                status=400,
+            )
+
+        year_week = episem(epidate, sep="")
+        return Response(
+            build_success_response(
+                {
+                    "epidemiological_week": year_week,
+                    "epidemiological_year": year_week[:4],
+                    "epidemiological_week_number": year_week[4:],
+                }
+            )
+        )
+
+
+class PublicNotificationReducedCSVView(NotificationReducedCSV_View):
+    """Preserve the existing public CSV response behavior under v1."""
+
+    permission_classes = [AllowAny]

--- a/AlertaDengue/api/v1/views.py
+++ b/AlertaDengue/api/v1/views.py
@@ -1,7 +1,9 @@
 """Views for the public REST API v1 surface."""
 
 from datetime import datetime
+from typing import Any
 
+import pandas as pd
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -10,6 +12,26 @@ from api.db import AlertCity
 from api.v1.responses import build_error_response, build_success_response
 from api.views import NotificationReducedCSV_View
 from dados.episem import episem
+
+
+def normalize_alert_city_records(
+    records: pd.DataFrame,
+) -> list[dict[str, Any]]:
+    """Convert DataFrame values to JSON-safe normalized API records."""
+    normalized_records = []
+    for record in records.to_dict("records"):
+        normalized_record: dict[str, Any] = {}
+        for field, value in record.items():
+            if value is None or pd.isna(value):
+                normalized_record[field] = None
+            elif isinstance(value, (datetime, pd.Timestamp)):
+                normalized_record[field] = value.isoformat()
+            elif hasattr(value, "item"):
+                normalized_record[field] = value.item()
+            else:
+                normalized_record[field] = value
+        normalized_records.append(normalized_record)
+    return normalized_records
 
 
 class PublicAPIRootView(APIView):
@@ -60,7 +82,9 @@ class PublicAlertCityView(APIView):
                 status=400,
             )
 
-        return Response(build_success_response(records.to_dict("records")))
+        return Response(
+            build_success_response(normalize_alert_city_records(records))
+        )
 
 
 class PublicEpiYearWeekView(APIView):

--- a/AlertaDengue/api/v1/views.py
+++ b/AlertaDengue/api/v1/views.py
@@ -1,0 +1,22 @@
+"""Views for the public REST API v1 surface."""
+
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class PublicAPIRootView(APIView):
+    """Describe the available public REST API v1 surface."""
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        """Return the public API version and currently available routes."""
+        return Response(
+            {
+                "api": "public",
+                "version": "v1",
+                "status": "ok",
+                "routes": {},
+            }
+        )

--- a/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
@@ -46,6 +46,35 @@ def test_v1_alert_city_uses_real_alert_city_service(monkeypatch):
     search.assert_called_once()
 
 
+def test_v1_alert_city_normalizes_non_json_pandas_values(monkeypatch):
+    monkeypatch.setattr(
+        views.AlertCity,
+        "search",
+        MagicMock(
+            return_value=pd.DataFrame(
+                [
+                    {
+                        "SE": 202601,
+                        "data_iniSE": pd.Timestamp("2026-01-04"),
+                        "casos": float("nan"),
+                        "nivel": pd.NaT,
+                    }
+                ]
+            )
+        ),
+    )
+
+    response = APIClient().get(
+        reverse("api:v1:alert_city"),
+        {"disease": "dengue", "geocode": "3304557"},
+    )
+
+    record = response.json()["data"][0]
+    assert record["epidemiological_week_start_date"] == "2026-01-04T00:00:00"
+    assert record["cases"] is None
+    assert record["alert_level"] is None
+
+
 def test_v1_epi_year_week_returns_normalized_response():
     response = APIClient().get(
         reverse("api:v1:epi_year_week"), {"epidate": "2026-01-04"}

--- a/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+from django.urls import reverse
+import pandas as pd
+from rest_framework.permissions import AllowAny
+from rest_framework.test import APIClient
+
+from api import views as legacy_views
+from api.internal.permissions import HasInternalAPIAccess
+from api.internal.views import HistoricalAlertListView
+from api.v1 import views
+from api.v1.views import PublicAlertCityView, PublicEpiYearWeekView
+
+
+def test_v1_and_legacy_routes_resolve():
+    assert reverse("api:v1:alert_city") == "/api/v1/alert-city/"
+    assert reverse("api:v1:epi_year_week") == "/api/v1/epi-year-week/"
+    assert reverse("api:v1:notification_reduced_csv").endswith("reduced.csv")
+    assert reverse("api:alertcity") == "/api/alertcity"
+
+
+def test_v1_root_regression():
+    assert APIClient().get(reverse("api:v1:root")).status_code == 200
+
+
+def test_public_and_internal_permissions_remain_separate():
+    assert PublicAlertCityView.permission_classes == [AllowAny]
+    assert PublicEpiYearWeekView.permission_classes == [AllowAny]
+    assert HistoricalAlertListView.permission_classes == [HasInternalAPIAccess]
+
+
+def test_v1_alert_city_uses_real_alert_city_service(monkeypatch):
+    search = MagicMock(
+        return_value=pd.DataFrame(
+            [{"SE": 202601, "municipio_geocodigo": 3304557, "casos": 3}]
+        )
+    )
+    monkeypatch.setattr(views.AlertCity, "search", search)
+    response = APIClient().get(
+        reverse("api:v1:alert_city"),
+        {"disease": "dengue", "geocode": "3304557"},
+    )
+    assert response.status_code == 200
+    assert response.json()["data"][0]["epidemiological_week"] == 202601
+    assert response.json()["data"][0]["municipality_geocode"] == 3304557
+    search.assert_called_once()
+
+
+def test_v1_epi_year_week_returns_normalized_response():
+    response = APIClient().get(
+        reverse("api:v1:epi_year_week"), {"epidate": "2026-01-04"}
+    )
+    assert response.status_code == 200
+    assert "epidemiological_week" in response.json()["data"]
+
+
+def test_v1_json_errors_use_response_helper_shape():
+    response = APIClient().get(reverse("api:v1:epi_year_week"))
+    assert response.status_code == 400
+    assert response.json()["code"] == "invalid_query"
+
+
+def test_v1_csv_delegates_to_legacy_response(monkeypatch):
+    query = MagicMock()
+    query.get_disease_dist.return_value.to_csv.return_value = (
+        "category,casos\n"
+    )
+    monkeypatch.setattr(
+        legacy_views,
+        "NotificationQueries",
+        lambda **kwargs: query,
+    )
+    response = APIClient().get(
+        reverse("api:v1:notification_reduced_csv"),
+        {"state_abv": "RJ", "chart_type": "disease"},
+    )
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/plain")

--- a/AlertaDengue/tests/api/test_public_rest_v1_structure.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_structure.py
@@ -1,0 +1,55 @@
+from django.urls import reverse
+from rest_framework.permissions import AllowAny
+from rest_framework.test import APIClient
+
+from api.internal.permissions import HasInternalAPIAccess
+from api.internal.views import HistoricalAlertListView
+from api.v1.responses import build_error_response, build_success_response
+from api.v1.views import PublicAPIRootView
+
+
+def test_public_rest_v1_root_route_returns_public_api_metadata():
+    response = APIClient().get(reverse("api:v1:root"))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "api": "public",
+        "version": "v1",
+        "status": "ok",
+        "routes": {},
+    }
+
+
+def test_existing_api_route_names_remain_resolvable():
+    assert reverse("api:alertcity") == "/api/alertcity"
+    assert reverse("api:internal:historical_alerts") == (
+        "/api/internal/historical-alerts/"
+    )
+
+
+def test_public_and_internal_rest_permissions_remain_separate():
+    assert PublicAPIRootView.permission_classes == [AllowAny]
+    assert HistoricalAlertListView.permission_classes == [HasInternalAPIAccess]
+    assert AllowAny not in HistoricalAlertListView.permission_classes
+
+
+def test_build_success_response_with_data_only():
+    assert build_success_response({"city": "Rio"}) == {"data": {"city": "Rio"}}
+
+
+def test_build_success_response_with_meta():
+    assert build_success_response([], meta={"limit": 10}) == {
+        "data": [],
+        "meta": {"limit": 10},
+    }
+
+
+def test_build_error_response_with_detail_only():
+    assert build_error_response("Not found") == {"detail": "Not found"}
+
+
+def test_build_error_response_with_code():
+    assert build_error_response("Not found", code="not_found") == {
+        "detail": "Not found",
+        "code": "not_found",
+    }

--- a/docs/api/public_rest_v1.md
+++ b/docs/api/public_rest_v1.md
@@ -12,3 +12,9 @@ read-only access. Reusable response helpers return either
 Legacy public endpoints remain in place for compatibility. Future migrations
 to public v1 will move one endpoint at a time, preserving explicit contracts
 and normalized English `snake_case` response fields.
+
+Current v1 routes add `/alert-city/`, `/epi-year-week/`, and
+`/notifications/reduced.csv`. The JSON endpoints use the response helpers;
+the reduced-notification endpoint intentionally remains CSV. Their legacy
+`/api/` routes remain available, while `/api/internal/` stays separate and
+restricted.

--- a/docs/api/public_rest_v1.md
+++ b/docs/api/public_rest_v1.md
@@ -1,8 +1,10 @@
 # Public REST API v1
 
-The public REST base route is `/api/v1/`. Its implementation package is
-`api/v1/`, which currently provides only `GET /api/v1/`. The root response
-identifies the public API, its `v1` version, status, and an empty route map.
+The public REST v1 routes are `GET /api/v1/`, `GET /api/v1/alert-city/`,
+`GET /api/v1/epi-year-week/`, and
+`GET /api/v1/notifications/reduced.csv`. Their implementation package is
+`api/v1/`. The root response identifies the public API, its `v1` version,
+status, and an empty route map.
 
 Public v1 endpoints use `AllowAny` only when their data is suitable for public
 read-only access. Reusable response helpers return either
@@ -13,8 +15,6 @@ Legacy public endpoints remain in place for compatibility. Future migrations
 to public v1 will move one endpoint at a time, preserving explicit contracts
 and normalized English `snake_case` response fields.
 
-Current v1 routes add `/alert-city/`, `/epi-year-week/`, and
-`/notifications/reduced.csv`. The JSON endpoints use the response helpers;
-the reduced-notification endpoint intentionally remains CSV. Their legacy
-`/api/` routes remain available, while `/api/internal/` stays separate and
-restricted.
+The JSON endpoints use the response helpers; the reduced-notification endpoint
+intentionally remains CSV. Their legacy `/api/` routes remain available, while
+`/api/internal/` stays separate and restricted.

--- a/docs/api/public_rest_v1.md
+++ b/docs/api/public_rest_v1.md
@@ -1,0 +1,14 @@
+# Public REST API v1
+
+The public REST base route is `/api/v1/`. Its implementation package is
+`api/v1/`, which currently provides only `GET /api/v1/`. The root response
+identifies the public API, its `v1` version, status, and an empty route map.
+
+Public v1 endpoints use `AllowAny` only when their data is suitable for public
+read-only access. Reusable response helpers return either
+`{"data": ..., "meta": ...}` success payloads or
+`{"detail": ..., "code": ...}` error payloads, with optional keys omitted.
+
+Legacy public endpoints remain in place for compatibility. Future migrations
+to public v1 will move one endpoint at a time, preserving explicit contracts
+and normalized English `snake_case` response fields.

--- a/docs/api/rest_api_architecture.md
+++ b/docs/api/rest_api_architecture.md
@@ -18,8 +18,8 @@ legacy public endpoints remain unchanged until then.
 Restricted endpoints for analysts, tools, and controlled external integrations
 live under `/api/internal/`. They use the existing token/group API permission.
 Internal services and views may live under `api.internal.*`; public REST
-endpoints should not. Internal API routes are not versioned now because their
-clients are controlled and restricted.
+endpoints should not live under `api.internal.*`. Internal API routes are not
+versioned now because their clients are controlled and restricted.
 
 ## Naming
 

--- a/docs/api/rest_api_architecture.md
+++ b/docs/api/rest_api_architecture.md
@@ -7,16 +7,19 @@ for backward compatibility. They are not refactored as part of the REST work.
 
 ## Public REST API
 
-A future public REST contract should use a versioned route such as `/api/v1/`.
-Public data may use `AllowAny` where appropriate. No public REST endpoint is
-implemented by this architecture document.
+The public REST base route is `/api/v1/`. Its versioned contract uses
+normalized English `snake_case` responses so future public consumers are not
+broken by later API evolution. Public read-only data may use `AllowAny` where
+appropriate. Future endpoint migrations will happen one endpoint at a time;
+legacy public endpoints remain unchanged until then.
 
 ## Internal REST API
 
 Restricted endpoints for analysts, tools, and controlled external integrations
 live under `/api/internal/`. They use the existing token/group API permission.
 Internal services and views may live under `api.internal.*`; public REST
-endpoints should not.
+endpoints should not. Internal API routes are not versioned now because their
+clients are controlled and restricted.
 
 ## Naming
 


### PR DESCRIPTION
### Description

This PR defines the public REST v1 structure under `/api/v1/` and adds v1 equivalents for selected legacy public endpoints.

Implemented and closes #1068 :

- `api.v1` package;
- `GET /api/v1/`;
- `GET /api/v1/alert-city/`;
- `GET /api/v1/epi-year-week/`;
- `GET /api/v1/notifications/reduced.csv`;
- public REST response helpers;
- JSON-safe normalization for alert-city records;
- tests for real routes, views, permissions, response helpers and legacy route compatibility;
- public REST v1 documentation;
- REST API architecture documentation.

Legacy `/api/` routes remain available. The internal `/api/internal/` API remains separate and restricted. No public historical-alert endpoint was added.

Validation:

- pre-commit hooks;
- `git diff --check`;
- compilation;
- Django check;
- `makemigrations --check --dry-run`: no changes detected;
- public v1 structure tests: 7 passed;
- public v1 legacy-migration tests: 8 passed;
- focused suite: 63 passed.

No migration, production connection, SQL write, migration apply, or physical database change was introduced.