### PR TITLE
refactor(api): route historical alerts through ORM adapters

### DIFF
--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -539,13 +539,18 @@ def get_last_alert(geo_id, disease, db_engine: Engine = DB_ENGINE):
     return pd.read_sql_query(sql, db_engine.raw_connection())
 
 
-def get_last_SE(disease: str = "dengue") -> Week:
+def get_last_SE(
+    disease: str = "dengue", db_engine: Engine | None = DB_ENGINE
+) -> Week:
     """Return the most recent epidemiological week for a disease.
 
     Parameters
     ----------
     disease
-        Disease key (e.g. "dengue", "chikungunya", "zika").
+        Disease key, for example ``dengue``, ``chikungunya`` or ``zika``.
+    db_engine
+        Retained for backward compatibility. The ORM-backed implementation
+        does not use this SQLAlchemy engine.
     Returns
     -------
     epiweeks.Week

--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Engine, Row
 
 # local
 from .episem import episem
+from .services.historical_alerts import get_latest_historical_alert_week
 
 logger = logging.getLogger(__name__)
 
@@ -538,18 +539,13 @@ def get_last_alert(geo_id, disease, db_engine: Engine = DB_ENGINE):
     return pd.read_sql_query(sql, db_engine.raw_connection())
 
 
-def get_last_SE(
-    disease: str = "dengue", db_engine: Engine = DB_ENGINE
-) -> Week:
+def get_last_SE(disease: str = "dengue") -> Week:
     """Return the most recent epidemiological week for a disease.
 
     Parameters
     ----------
     disease
         Disease key (e.g. "dengue", "chikungunya", "zika").
-    db_engine
-        SQLAlchemy engine.
-
     Returns
     -------
     epiweeks.Week
@@ -560,23 +556,11 @@ def get_last_SE(
     ValueError
         If the table has no rows.
     """
-    table_name = f"Historico_alerta{get_disease_suffix(disease)}"
-    stmt = text(
-        f"""
-        SELECT "SE"
-        FROM "Municipio"."{table_name}"
-        ORDER BY "data_iniSE" DESC
-        LIMIT 1
-        """
-    )
-
-    with db_engine.connect() as conn:
-        row = conn.execute(stmt).first()
-
-    if row is None:
+    latest_week = get_latest_historical_alert_week(disease)
+    if latest_week is None:
         raise ValueError(f"No rows found for disease={disease!r}")
 
-    return Week.fromstring(str(row[0]))
+    return Week.fromstring(str(latest_week))
 
 
 def load_cases_without_forecast(

--- a/AlertaDengue/dados/services/historical_alerts.py
+++ b/AlertaDengue/dados/services/historical_alerts.py
@@ -45,7 +45,10 @@ def get_latest_historical_alert_week(disease: str) -> int | None:
     """
     model = get_legacy_historical_alert_model(disease)
     return (
-        model.objects.order_by("-epidemiological_week_start_date")
+        model.objects.order_by(
+            "-epidemiological_week_start_date",
+            "-epidemiological_week",
+        )
         .values_list("epidemiological_week", flat=True)
         .first()
     )

--- a/AlertaDengue/dados/services/historical_alerts.py
+++ b/AlertaDengue/dados/services/historical_alerts.py
@@ -35,3 +35,17 @@ def get_legacy_historical_alert_model(disease: str):
 
 def get_legacy_historical_alert_table_name(disease: str) -> str:
     return get_legacy_historical_alert_model(disease)._meta.db_table
+
+
+def get_latest_historical_alert_week(disease: str) -> int | None:
+    """Return the newest epidemiological week through the ORM adapter.
+
+    This intentionally exposes the normalized service operation rather than
+    the legacy ``SE`` database column used by the retained tables.
+    """
+    model = get_legacy_historical_alert_model(disease)
+    return (
+        model.objects.order_by("-epidemiological_week_start_date")
+        .values_list("epidemiological_week", flat=True)
+        .first()
+    )

--- a/AlertaDengue/tests/api/test_historical_alert_service.py
+++ b/AlertaDengue/tests/api/test_historical_alert_service.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,12 +11,17 @@ from api.internal.historical_alerts import (
     get_historical_alert_response_fields,
     serialize_historical_alert,
 )
+from dados import dbdata
 from dados.models import (
     LegacyHistoricalAlertChikungunya,
     LegacyHistoricalAlertDengue,
     LegacyHistoricalAlertZika,
 )
-from dados.services.historical_alerts import get_legacy_historical_alert_model
+from dados.services import historical_alerts
+from dados.services.historical_alerts import (
+    get_latest_historical_alert_week,
+    get_legacy_historical_alert_model,
+)
 
 
 @pytest.mark.parametrize(
@@ -36,6 +42,37 @@ def test_historical_alert_disease_routing(disease, model):
 def test_historical_alert_service_rejects_unknown_disease():
     with pytest.raises(ValueError, match="supported values"):
         HistoricalAlertFilters("yellow-fever")
+
+
+def test_latest_historical_alert_week_uses_normalized_orm_fields(monkeypatch):
+    values = MagicMock()
+    values.first.return_value = 202601
+    queryset = MagicMock()
+    queryset.values_list.return_value = values
+    model = MagicMock()
+    model.objects.order_by.return_value = queryset
+    monkeypatch.setattr(
+        historical_alerts,
+        "get_legacy_historical_alert_model",
+        lambda disease: model,
+    )
+
+    assert get_latest_historical_alert_week("chik") == 202601
+    model.objects.order_by.assert_called_once_with(
+        "-epidemiological_week_start_date"
+    )
+    queryset.values_list.assert_called_once_with(
+        "epidemiological_week", flat=True
+    )
+    values.first.assert_called_once_with()
+
+
+def test_get_last_se_delegates_to_the_historical_alert_service(monkeypatch):
+    service = MagicMock(return_value=202601)
+    monkeypatch.setattr(dbdata, "get_latest_historical_alert_week", service)
+
+    assert dbdata.get_last_SE("zika").cdcformat() == "202601"
+    service.assert_called_once_with("zika")
 
 
 def test_historical_alert_queryset_uses_normalized_filters_and_table():

--- a/AlertaDengue/tests/api/test_historical_alert_service.py
+++ b/AlertaDengue/tests/api/test_historical_alert_service.py
@@ -98,7 +98,7 @@ def test_latest_historical_alert_week_reads_real_orm_adapter(
         municipality_geocode=3304557,
     )
     model.objects.create(
-        epidemiological_week_start_date=date(2026, 1, 11),
+        epidemiological_week_start_date=date(2026, 1, 4),
         epidemiological_week=202602,
         municipality_geocode=3304557,
     )

--- a/AlertaDengue/tests/api/test_historical_alert_service.py
+++ b/AlertaDengue/tests/api/test_historical_alert_service.py
@@ -1,6 +1,6 @@
 from datetime import date
-from unittest.mock import MagicMock
 
+from django.db import connections
 import pytest
 
 from api.internal.historical_alerts import (
@@ -17,7 +17,6 @@ from dados.models import (
     LegacyHistoricalAlertDengue,
     LegacyHistoricalAlertZika,
 )
-from dados.services import historical_alerts
 from dados.services.historical_alerts import (
     get_latest_historical_alert_week,
     get_legacy_historical_alert_model,
@@ -44,35 +43,96 @@ def test_historical_alert_service_rejects_unknown_disease():
         HistoricalAlertFilters("yellow-fever")
 
 
-def test_latest_historical_alert_week_uses_normalized_orm_fields(monkeypatch):
-    values = MagicMock()
-    values.first.return_value = 202601
-    queryset = MagicMock()
-    queryset.values_list.return_value = values
-    model = MagicMock()
-    model.objects.order_by.return_value = queryset
-    monkeypatch.setattr(
-        historical_alerts,
-        "get_legacy_historical_alert_model",
-        lambda disease: model,
+@pytest.fixture
+def historical_alert_tables():
+    """Create unmanaged historical-alert tables in the Django test DB."""
+    database_connection = connections["dados"]
+    if database_connection.vendor != "postgresql":
+        pytest.skip(
+            "historical alert adapters use PostgreSQL schema-qualified tables"
+        )
+
+    models = (
+        LegacyHistoricalAlertDengue,
+        LegacyHistoricalAlertChikungunya,
+        LegacyHistoricalAlertZika,
     )
 
-    assert get_latest_historical_alert_week("chik") == 202601
-    model.objects.order_by.assert_called_once_with(
-        "-epidemiological_week_start_date"
+    with database_connection.cursor() as cursor:
+        cursor.execute('CREATE SCHEMA IF NOT EXISTS "Municipio"')
+        for model in reversed(models):
+            cursor.execute(
+                f"DROP TABLE IF EXISTS {model._meta.db_table} CASCADE"
+            )
+
+    with database_connection.schema_editor() as schema_editor:
+        for model in models:
+            schema_editor.create_model(model)
+
+    yield
+
+    with database_connection.cursor() as cursor:
+        for model in reversed(models):
+            cursor.execute(
+                f"DROP TABLE IF EXISTS {model._meta.db_table} CASCADE"
+            )
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+@pytest.mark.parametrize(
+    ("disease", "model"),
+    [
+        ("dengue", LegacyHistoricalAlertDengue),
+        ("chik", LegacyHistoricalAlertChikungunya),
+        ("zika", LegacyHistoricalAlertZika),
+    ],
+)
+def test_latest_historical_alert_week_reads_real_orm_adapter(
+    historical_alert_tables,
+    disease,
+    model,
+):
+    model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=3304557,
     )
-    queryset.values_list.assert_called_once_with(
-        "epidemiological_week", flat=True
+    model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 11),
+        epidemiological_week=202602,
+        municipality_geocode=3304557,
     )
-    values.first.assert_called_once_with()
+
+    assert get_latest_historical_alert_week(disease) == 202602
 
 
-def test_get_last_se_delegates_to_the_historical_alert_service(monkeypatch):
-    service = MagicMock(return_value=202601)
-    monkeypatch.setattr(dbdata, "get_latest_historical_alert_week", service)
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_latest_historical_alert_week_returns_none_for_empty_table(
+    historical_alert_tables,
+):
+    assert get_latest_historical_alert_week("dengue") is None
 
-    assert dbdata.get_last_SE("zika").cdcformat() == "202601"
-    service.assert_called_once_with("zika")
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_get_last_se_reads_real_historical_alert_adapter(
+    historical_alert_tables,
+):
+    LegacyHistoricalAlertZika.objects.create(
+        epidemiological_week_start_date=date(2026, 2, 8),
+        epidemiological_week=202606,
+        municipality_geocode=3304557,
+    )
+
+    assert dbdata.get_last_SE("zika").cdcformat() == "202606"
+    assert dbdata.get_last_SE("zika", db_engine=None).cdcformat() == "202606"
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_get_last_se_raises_for_empty_historical_alert_table(
+    historical_alert_tables,
+):
+    with pytest.raises(ValueError, match="No rows found for disease='dengue'"):
+        dbdata.get_last_SE("dengue")
 
 
 def test_historical_alert_queryset_uses_normalized_filters_and_table():

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -30,10 +30,11 @@ The service deliberately leaves dashboard and report raw SQL unchanged until
 those paths are benchmarked. It introduces no migrations, production database
 connections, SQL writes, or physical database changes.
 
-The small `dados.dbdata.get_last_SE` lookup is routed through the same adapter
-service. The legacy `/api/alertcity/` implementation and public v1 wrapper
-still use `AlertCity.search`: their compatibility response includes additional
-legacy-table fields and an unbounded range aggregate that the bounded internal
-historical-alert service intentionally does not expose. Report, dashboard, and
-geofile SQL also remain explicit exceptions because they require joins, window
-functions, or legacy DataFrame-shaped results.
+The small `dados.dbdata.get_last_SE` lookup is routed through the same
+ORM-backed adapter service. The legacy `/api/alertcity/` implementation still
+uses `AlertCity.search` to preserve its compatibility response. The public v1
+alert-city endpoint also keeps `AlertCity.search` as its data boundary, but
+normalizes and filters the response contract at the API layer.
+
+Report, dashboard, and geofile SQL remain explicit exceptions because they
+require joins, window functions, or legacy DataFrame-shaped results.

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -29,3 +29,11 @@ remain separate and unmanaged. The #1042 physical merge remains deferred.
 The service deliberately leaves dashboard and report raw SQL unchanged until
 those paths are benchmarked. It introduces no migrations, production database
 connections, SQL writes, or physical database changes.
+
+The small `dados.dbdata.get_last_SE` lookup is routed through the same adapter
+service. The legacy `/api/alertcity/` implementation and public v1 wrapper
+still use `AlertCity.search`: their compatibility response includes additional
+legacy-table fields and an unbounded range aggregate that the bounded internal
+historical-alert service intentionally does not expose. Report, dashboard, and
+geofile SQL also remain explicit exceptions because they require joins, window
+functions, or legacy DataFrame-shaped results.


### PR DESCRIPTION
## Description

Refactor historical alert read access to use the unmanaged ORM adapters through the historical alert service layer.

This builds on the retained historical alert ORM mappings and routes the small `get_last_SE` lookup through the normalized service path.
- Closes #1074
## Changes

- add `get_latest_historical_alert_week()` using the historical alert ORM adapters;
- route `dados.dbdata.get_last_SE()` through the historical alert service;
- keep the `db_engine` parameter for backward compatibility;
- document the remaining raw SQL/legacy exceptions.


