### PR TITLE
refactor(api): isolate public alert-city v1 data access

### DIFF
--- a/AlertaDengue/api/v1/services.py
+++ b/AlertaDengue/api/v1/services.py
@@ -1,0 +1,93 @@
+"""Service boundaries for the public REST API v1 surface."""
+
+from datetime import date, datetime
+from typing import Any
+
+import pandas as pd
+
+from api.db import AlertCity
+
+__all__ = [
+    "ALERT_CITY_FIELD_MAP",
+    "ALERT_CITY_RESPONSE_FIELDS",
+    "get_public_alert_city_records",
+    "normalize_public_alert_city_records",
+]
+
+
+ALERT_CITY_FIELD_MAP = {
+    "data_iniSE": "epidemiological_week_start_date",
+    "SE": "epidemiological_week",
+    "casos_est": "estimated_cases",
+    "casos_est_min": "estimated_cases_min",
+    "casos_est_max": "estimated_cases_max",
+    "casos": "cases",
+    "municipio_geocodigo": "municipality_geocode",
+    "municipio_nome": "municipality_name",
+    "p_rt1": "rt1_probability",
+    "p_inc100k": "incidence_100k_probability",
+    "Localidade_id": "locality_id",
+    "nivel": "alert_level",
+    "id": "id",
+    "versao_modelo": "model_version",
+    "Rt": "reproduction_number",
+    "pop": "population",
+    "tempmin": "temperature_min",
+    "tempmed": "temperature_mean",
+    "tempmax": "temperature_max",
+    "umidmin": "humidity_min",
+    "umidmed": "humidity_mean",
+    "umidmax": "humidity_max",
+    "receptivo": "receptive",
+    "transmissao": "transmission",
+    "nivel_inc": "incidence_level",
+    "casprov": "probable_cases",
+    "casprov_est": "estimated_probable_cases",
+    "casprov_est_min": "estimated_probable_cases_min",
+    "casprov_est_max": "estimated_probable_cases_max",
+    "casconf": "confirmed_cases",
+    "notif_accum_year": "notifications_accumulated_year",
+}
+ALERT_CITY_RESPONSE_FIELDS = tuple(ALERT_CITY_FIELD_MAP.values())
+
+
+def normalize_public_alert_city_records(
+    records: pd.DataFrame,
+) -> list[dict[str, Any]]:
+    """Return the allowlisted, JSON-safe public v1 alert-city records."""
+    normalized_records = []
+    for record in records.rename(columns=ALERT_CITY_FIELD_MAP).to_dict(
+        "records"
+    ):
+        normalized_record: dict[str, Any] = {}
+        for field in ALERT_CITY_RESPONSE_FIELDS:
+            if field not in record:
+                continue
+            value = record[field]
+            if value is None or pd.isna(value):
+                normalized_record[field] = None
+            elif hasattr(value, "item"):
+                value = value.item()
+
+                if isinstance(value, (date, datetime, pd.Timestamp)):
+                    normalized_record[field] = value.isoformat()
+                else:
+                    normalized_record[field] = value
+            elif isinstance(value, (date, datetime, pd.Timestamp)):
+                normalized_record[field] = value.isoformat()
+            else:
+                normalized_record[field] = value
+        normalized_records.append(normalized_record)
+    return normalized_records
+
+
+def get_public_alert_city_records(
+    *,
+    disease: str,
+    geocode: str | int | None,
+    ew_start: int | None,
+    ew_end: int | None,
+) -> list[dict[str, Any]]:
+    """Fetch and normalize alert-city records for the public v1 contract."""
+    records = AlertCity.search(disease, geocode, ew_start, ew_end)
+    return normalize_public_alert_city_records(records)

--- a/AlertaDengue/api/v1/views.py
+++ b/AlertaDengue/api/v1/views.py
@@ -1,75 +1,15 @@
 """Views for the public REST API v1 surface."""
 
 from datetime import datetime
-from typing import Any
 
-import pandas as pd
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from api.db import AlertCity
 from api.v1.responses import build_error_response, build_success_response
+from api.v1.services import get_public_alert_city_records
 from api.views import NotificationReducedCSV_View
 from dados.episem import episem
-
-ALERT_CITY_FIELD_MAP = {
-    "data_iniSE": "epidemiological_week_start_date",
-    "SE": "epidemiological_week",
-    "casos_est": "estimated_cases",
-    "casos_est_min": "estimated_cases_min",
-    "casos_est_max": "estimated_cases_max",
-    "casos": "cases",
-    "municipio_geocodigo": "municipality_geocode",
-    "municipio_nome": "municipality_name",
-    "p_rt1": "rt1_probability",
-    "p_inc100k": "incidence_100k_probability",
-    "Localidade_id": "locality_id",
-    "nivel": "alert_level",
-    "id": "id",
-    "versao_modelo": "model_version",
-    "Rt": "reproduction_number",
-    "pop": "population",
-    "tempmin": "temperature_min",
-    "tempmed": "temperature_mean",
-    "tempmax": "temperature_max",
-    "umidmin": "humidity_min",
-    "umidmed": "humidity_mean",
-    "umidmax": "humidity_max",
-    "receptivo": "receptive",
-    "transmissao": "transmission",
-    "nivel_inc": "incidence_level",
-    "casprov": "probable_cases",
-    "casprov_est": "estimated_probable_cases",
-    "casprov_est_min": "estimated_probable_cases_min",
-    "casprov_est_max": "estimated_probable_cases_max",
-    "casconf": "confirmed_cases",
-    "notif_accum_year": "notifications_accumulated_year",
-}
-ALERT_CITY_RESPONSE_FIELDS = tuple(ALERT_CITY_FIELD_MAP.values())
-
-
-def normalize_alert_city_records(
-    records: pd.DataFrame,
-) -> list[dict[str, Any]]:
-    """Convert DataFrame values to JSON-safe normalized API records."""
-    normalized_records = []
-    for record in records.to_dict("records"):
-        normalized_record: dict[str, Any] = {}
-        for field in ALERT_CITY_RESPONSE_FIELDS:
-            if field not in record:
-                continue
-            value = record[field]
-            if value is None or pd.isna(value):
-                normalized_record[field] = None
-            elif isinstance(value, (datetime, pd.Timestamp)):
-                normalized_record[field] = value.isoformat()
-            elif hasattr(value, "item"):
-                normalized_record[field] = value.item()
-            else:
-                normalized_record[field] = value
-        normalized_records.append(normalized_record)
-    return normalized_records
 
 
 class PublicAPIRootView(APIView):
@@ -100,21 +40,19 @@ class PublicAlertCityView(APIView):
             geocode = int(request.query_params["geocode"])
             ew_start = request.query_params.get("ew_start")
             ew_end = request.query_params.get("ew_end")
-            records = AlertCity.search(
-                disease,
-                geocode,
-                int(ew_start) if ew_start else None,
-                int(ew_end) if ew_end else None,
-            ).rename(columns=ALERT_CITY_FIELD_MAP)
+            records = get_public_alert_city_records(
+                disease=disease,
+                geocode=geocode,
+                ew_start=int(ew_start) if ew_start else None,
+                ew_end=int(ew_end) if ew_end else None,
+            )
         except (KeyError, ValueError) as exc:
             return Response(
                 build_error_response(str(exc), code="invalid_query"),
                 status=400,
             )
 
-        return Response(
-            build_success_response(normalize_alert_city_records(records))
-        )
+        return Response(build_success_response(records))
 
 
 class PublicEpiYearWeekView(APIView):

--- a/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
@@ -1,16 +1,21 @@
-from unittest.mock import MagicMock
-
 from django.urls import reverse
 import numpy as np
 import pandas as pd
 from rest_framework.permissions import AllowAny
 from rest_framework.test import APIClient
 
-from api import views as legacy_views
 from api.internal.permissions import HasInternalAPIAccess
 from api.internal.views import HistoricalAlertListView
-from api.v1 import views
-from api.v1.views import PublicAlertCityView, PublicEpiYearWeekView
+from api.v1.services import (
+    ALERT_CITY_RESPONSE_FIELDS,
+    normalize_public_alert_city_records,
+)
+from api.v1.views import (
+    PublicAlertCityView,
+    PublicEpiYearWeekView,
+    PublicNotificationReducedCSVView,
+)
+from api.views import NotificationReducedCSV_View
 
 
 def test_v1_and_legacy_routes_resolve():
@@ -30,7 +35,7 @@ def test_public_and_internal_permissions_remain_separate():
     assert HistoricalAlertListView.permission_classes == [HasInternalAPIAccess]
 
 
-def test_v1_alert_city_uses_real_alert_city_service(monkeypatch):
+def test_public_alert_city_normalizes_allowlisted_legacy_fields():
     legacy_record = {
         "data_iniSE": pd.Timestamp("2026-01-04"),
         "SE": np.int64(202601),
@@ -66,15 +71,10 @@ def test_v1_alert_city_uses_real_alert_city_service(monkeypatch):
         "tweet": "excluded",
         "unmapped_field": "excluded",
     }
-    search = MagicMock(return_value=pd.DataFrame([legacy_record]))
-    monkeypatch.setattr(views.AlertCity, "search", search)
-    response = APIClient().get(
-        reverse("api:v1:alert_city"),
-        {"disease": "dengue", "geocode": "3304557"},
-    )
-    assert response.status_code == 200
-    record = response.json()["data"][0]
-    assert set(record) == set(views.ALERT_CITY_RESPONSE_FIELDS)
+    record = normalize_public_alert_city_records(
+        pd.DataFrame([legacy_record])
+    )[0]
+    assert set(record) == set(ALERT_CITY_RESPONSE_FIELDS)
     assert record == {
         "epidemiological_week_start_date": "2026-01-04T00:00:00",
         "epidemiological_week": 202601,
@@ -142,34 +142,24 @@ def test_v1_alert_city_uses_real_alert_city_service(monkeypatch):
         "notif_accum_year",
         "unmapped_field",
     } & set(record)
-    search.assert_called_once()
 
 
-def test_v1_alert_city_normalizes_non_json_pandas_values(monkeypatch):
-    monkeypatch.setattr(
-        views.AlertCity,
-        "search",
-        MagicMock(
-            return_value=pd.DataFrame(
-                [
-                    {
-                        "SE": 202601,
-                        "data_iniSE": pd.Timestamp("2026-01-04"),
-                        "casos": float("nan"),
-                        "nivel": pd.NaT,
-                    }
-                ]
-            )
-        ),
-    )
+def test_public_alert_city_normalizes_pandas_and_numpy_values():
+    record = normalize_public_alert_city_records(
+        pd.DataFrame(
+            [
+                {
+                    "SE": np.int64(202601),
+                    "data_iniSE": pd.Timestamp("2026-01-04"),
+                    "casos": np.nan,
+                    "nivel": pd.NaT,
+                }
+            ]
+        )
+    )[0]
 
-    response = APIClient().get(
-        reverse("api:v1:alert_city"),
-        {"disease": "dengue", "geocode": "3304557"},
-    )
-
-    record = response.json()["data"][0]
     assert record["epidemiological_week_start_date"] == "2026-01-04T00:00:00"
+    assert record["epidemiological_week"] == 202601
     assert record["cases"] is None
     assert record["alert_level"] is None
 
@@ -188,19 +178,8 @@ def test_v1_json_errors_use_response_helper_shape():
     assert response.json()["code"] == "invalid_query"
 
 
-def test_v1_csv_delegates_to_legacy_response(monkeypatch):
-    query = MagicMock()
-    query.get_disease_dist.return_value.to_csv.return_value = (
-        "category,casos\n"
+def test_v1_csv_preserves_legacy_response_class():
+    assert issubclass(
+        PublicNotificationReducedCSVView, NotificationReducedCSV_View
     )
-    monkeypatch.setattr(
-        legacy_views,
-        "NotificationQueries",
-        lambda **kwargs: query,
-    )
-    response = APIClient().get(
-        reverse("api:v1:notification_reduced_csv"),
-        {"state_abv": "RJ", "chart_type": "disease"},
-    )
-    assert response.status_code == 200
-    assert response["Content-Type"].startswith("text/plain")
+    assert PublicNotificationReducedCSVView.permission_classes == [AllowAny]

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -30,11 +30,13 @@ The service deliberately leaves dashboard and report raw SQL unchanged until
 those paths are benchmarked. It introduces no migrations, production database
 connections, SQL writes, or physical database changes.
 
-The small `dados.dbdata.get_last_SE` lookup is routed through the same
-ORM-backed adapter service. The legacy `/api/alertcity/` implementation still
-uses `AlertCity.search` to preserve its compatibility response. The public v1
-alert-city endpoint also keeps `AlertCity.search` as its data boundary, but
-normalizes and filters the response contract at the API layer.
+Internal historical access and small lookups such as
+`dados.dbdata.get_last_SE` use the ORM-backed adapter service. The legacy
+`/api/alertcity/` implementation remains unchanged and uses `AlertCity.search`
+for its compatibility response. Public v1 alert-city has a dedicated service
+boundary that keeps `AlertCity.search`, because its legacy DataFrame shape
+supplies weather, population, receptivity/transmission/incidence, and
+accumulated-notification fields unavailable from historical ORM adapters.
 
 Report, dashboard, and geofile SQL remain explicit exceptions because they
 require joins, window functions, or legacy DataFrame-shaped results.

--- a/docs/api/public_rest_v1.md
+++ b/docs/api/public_rest_v1.md
@@ -61,4 +61,9 @@ the following normalized public v1 fields when available from the query result:
 `tweet` is not part of the public v1 contract. Fields outside the documented
 contract are omitted. Fields in the contract with a missing, `NaN`, or `NaT`
 source value may be returned as `null`. Physical database columns are unchanged;
-normalization occurs at the API response layer.
+normalization occurs in the dedicated public v1 alert-city service boundary.
+That service preserves the normalized public v1 response contract while it
+continues to use `AlertCity.search` as its data boundary: weather,
+receptivity/transmission/incidence indicators, population, and accumulated
+notification fields are not all available from the historical-alert ORM adapters
+alone.


### PR DESCRIPTION
## Description

Refactor the public `/api/v1/alert-city/` endpoint to use a dedicated public v1 service boundary for data access and response normalization.

This keeps the public v1 response contract unchanged while moving the alert-city field mapping and JSON-safe normalization out of the view layer.

### Changes

- add `api.v1.services` as the public v1 alert-city service boundary;
- move alert-city field mapping and response allowlist into the service layer;
- move public v1 alert-city normalization into `normalize_public_alert_city_records`;
- keep `AlertCity.search` as the public v1 data boundary;
- simplify `PublicAlertCityView`;
- remove `MagicMock` and `monkeypatch` from the changed public v1 tests;
- document why full public v1 alert-city migration to ORM adapters remains blocked.

### Why `AlertCity.search` remains

The public v1 alert-city contract still includes fields that are not all available from the historical-alert ORM adapters alone, including:

- weather fields;
- population;
- receptivity/transmission/incidence indicators;
- accumulated notification fields.

For now, `AlertCity.search` remains the compatibility data boundary, while normalization is isolated in the public v1 service layer.

### Out of scope

- no legacy `/api/alertcity/` change;
- no public v1 response contract change;
- no internal historical-alert endpoint change;
- no ORM model change;
- no migration;
- no schema change;
- no production database action.