### PR TITLE
refactor(api): route public alert-city v1 through historical alert service

### DIFF
--- a/AlertaDengue/api/v1/services.py
+++ b/AlertaDengue/api/v1/services.py
@@ -5,13 +5,16 @@ from typing import Any
 
 import pandas as pd
 
-from api.db import AlertCity
+from dados.services.historical_alerts import (
+    build_historical_alert_records_queryset,
+)
 
 __all__ = [
     "ALERT_CITY_FIELD_MAP",
     "ALERT_CITY_RESPONSE_FIELDS",
     "get_public_alert_city_records",
     "normalize_public_alert_city_records",
+    "serialize_public_alert_city_record",
 ]
 
 
@@ -89,5 +92,30 @@ def get_public_alert_city_records(
     ew_end: int | None,
 ) -> list[dict[str, Any]]:
     """Fetch and normalize alert-city records for the public v1 contract."""
-    records = AlertCity.search(disease, geocode, ew_start, ew_end)
-    return normalize_public_alert_city_records(records)
+    if geocode is None:
+        raise ValueError("geocode is required")
+    queryset = build_historical_alert_records_queryset(
+        disease=disease,
+        municipality_geocode=int(geocode),
+        start_week=ew_start,
+        end_week=ew_end,
+    )
+    return [serialize_public_alert_city_record(record) for record in queryset]
+
+
+def serialize_public_alert_city_record(record: Any) -> dict[str, Any]:
+    """Serialize an ORM adapter row using only public v1 field names."""
+    serialized: dict[str, Any] = {}
+    for field in ALERT_CITY_RESPONSE_FIELDS:
+        value = getattr(record, field, None)
+        if field == "epidemiological_week_start_date" and isinstance(
+            value, date
+        ):
+            serialized[field] = datetime.combine(
+                value, datetime.min.time()
+            ).isoformat()
+        elif isinstance(value, datetime):
+            serialized[field] = value.isoformat()
+        else:
+            serialized[field] = value
+    return serialized

--- a/AlertaDengue/api/v1/views.py
+++ b/AlertaDengue/api/v1/views.py
@@ -30,7 +30,7 @@ class PublicAPIRootView(APIView):
 
 
 class PublicAlertCityView(APIView):
-    """Return normalized city-alert records through the legacy query service."""
+    """Return normalized city-alert records through historical-alert ORM."""
 
     permission_classes = [AllowAny]
 

--- a/AlertaDengue/dados/models/municipio.py
+++ b/AlertaDengue/dados/models/municipio.py
@@ -29,6 +29,19 @@ class LegacyHistoricalAlertBase(models.Model):
     model_version = models.CharField(
         db_column="versao_modelo", max_length=40, null=True
     )
+    reproduction_number = models.FloatField(db_column="Rt", null=True)
+    population = models.IntegerField(db_column="pop", null=True)
+    temperature_min = models.FloatField(db_column="tempmin", null=True)
+    temperature_mean = models.FloatField(db_column="tempmed", null=True)
+    temperature_max = models.FloatField(db_column="tempmax", null=True)
+    humidity_min = models.FloatField(db_column="umidmin", null=True)
+    humidity_mean = models.FloatField(db_column="umidmed", null=True)
+    humidity_max = models.FloatField(db_column="umidmax", null=True)
+    receptive = models.SmallIntegerField(db_column="receptivo", null=True)
+    transmission = models.SmallIntegerField(db_column="transmissao", null=True)
+    incidence_level = models.SmallIntegerField(
+        db_column="nivel_inc", null=True
+    )
     municipality_name = models.CharField(
         db_column="municipio_nome", max_length=128, null=True
     )

--- a/AlertaDengue/dados/services/historical_alerts.py
+++ b/AlertaDengue/dados/services/historical_alerts.py
@@ -37,6 +37,27 @@ def get_legacy_historical_alert_table_name(disease: str) -> str:
     return get_legacy_historical_alert_model(disease)._meta.db_table
 
 
+def build_historical_alert_records_queryset(
+    *,
+    disease: str,
+    municipality_geocode: int,
+    start_week: int | None = None,
+    end_week: int | None = None,
+):
+    """Return public-record candidates from the selected retained table."""
+    model = get_legacy_historical_alert_model(disease)
+    queryset = model.objects.filter(municipality_geocode=municipality_geocode)
+
+    if start_week is not None:
+        queryset = queryset.filter(epidemiological_week__gte=start_week)
+    if end_week is not None:
+        queryset = queryset.filter(epidemiological_week__lte=end_week)
+
+    return queryset.order_by(
+        "epidemiological_week_start_date", "epidemiological_week", "id"
+    )
+
+
 def get_latest_historical_alert_week(disease: str) -> int | None:
     """Return the newest epidemiological week through the ORM adapter.
 

--- a/AlertaDengue/tests/api/test_historical_alert_service.py
+++ b/AlertaDengue/tests/api/test_historical_alert_service.py
@@ -18,6 +18,7 @@ from dados.models import (
     LegacyHistoricalAlertZika,
 )
 from dados.services.historical_alerts import (
+    build_historical_alert_records_queryset,
     get_latest_historical_alert_week,
     get_legacy_historical_alert_model,
 )
@@ -168,6 +169,24 @@ def test_historical_alert_range_filters_and_ordering_are_applied():
     assert '"data_iniSE" >=' in sql
     assert '"data_iniSE" <=' in sql
     assert '"SE" ASC' in sql
+
+
+def test_public_historical_alert_records_queryset_uses_normalized_fields():
+    queryset = build_historical_alert_records_queryset(
+        disease="dengue",
+        municipality_geocode=3304557,
+        start_week=202601,
+        end_week=202652,
+    )
+
+    sql = str(queryset.query)
+
+    assert queryset.model is LegacyHistoricalAlertDengue
+    assert '"municipio_geocodigo"' in sql
+    assert '"SE" >=' in sql
+    assert '"SE" <=' in sql
+    assert '"data_iniSE" ASC' in sql
+    assert '"id" ASC' in sql
 
 
 @pytest.mark.parametrize(

--- a/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
@@ -1,6 +1,10 @@
+from datetime import date
+
+from django.db import connections
 from django.urls import reverse
 import numpy as np
 import pandas as pd
+import pytest
 from rest_framework.permissions import AllowAny
 from rest_framework.test import APIClient
 
@@ -8,6 +12,7 @@ from api.internal.permissions import HasInternalAPIAccess
 from api.internal.views import HistoricalAlertListView
 from api.v1.services import (
     ALERT_CITY_RESPONSE_FIELDS,
+    get_public_alert_city_records,
     normalize_public_alert_city_records,
 )
 from api.v1.views import (
@@ -16,6 +21,188 @@ from api.v1.views import (
     PublicNotificationReducedCSVView,
 )
 from api.views import NotificationReducedCSV_View
+from dados.models import (
+    LegacyHistoricalAlertChikungunya,
+    LegacyHistoricalAlertDengue,
+    LegacyHistoricalAlertZika,
+)
+
+
+@pytest.fixture
+def public_historical_alert_tables():
+    """Create the unmanaged alert tables used by the public v1 service."""
+    database_connection = connections["dados"]
+    if database_connection.vendor != "postgresql":
+        pytest.skip("historical alert adapters require PostgreSQL schemas")
+
+    models = (
+        LegacyHistoricalAlertDengue,
+        LegacyHistoricalAlertChikungunya,
+        LegacyHistoricalAlertZika,
+    )
+    with database_connection.cursor() as cursor:
+        cursor.execute('CREATE SCHEMA IF NOT EXISTS "Municipio"')
+        for model in reversed(models):
+            cursor.execute(
+                f"DROP TABLE IF EXISTS {model._meta.db_table} CASCADE"
+            )
+    with database_connection.schema_editor() as schema_editor:
+        for model in models:
+            schema_editor.create_model(model)
+
+    yield
+
+    with database_connection.cursor() as cursor:
+        for model in reversed(models):
+            cursor.execute(
+                f"DROP TABLE IF EXISTS {model._meta.db_table} CASCADE"
+            )
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+@pytest.mark.parametrize(
+    ("disease", "model"),
+    [
+        ("dengue", LegacyHistoricalAlertDengue),
+        ("chik", LegacyHistoricalAlertChikungunya),
+        ("zika", LegacyHistoricalAlertZika),
+    ],
+)
+def test_public_alert_city_service_uses_orm_disease_filtering_and_ordering(
+    public_historical_alert_tables, disease, model
+):
+    other_model = (
+        LegacyHistoricalAlertZika
+        if model is not LegacyHistoricalAlertZika
+        else LegacyHistoricalAlertDengue
+    )
+    second = model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 11),
+        epidemiological_week=202602,
+        municipality_geocode=3304557,
+        municipality_name="Rio",
+    )
+    first = model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=3304557,
+        municipality_name="Rio",
+    )
+    model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=9999999,
+    )
+    other_model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=3304557,
+    )
+
+    records = get_public_alert_city_records(
+        disease=disease, geocode=3304557, ew_start=202601, ew_end=202602
+    )
+
+    assert [record["id"] for record in records] == [first.id, second.id]
+    assert all(
+        set(record) == set(ALERT_CITY_RESPONSE_FIELDS) for record in records
+    )
+    assert "tweet" not in records[0]
+    assert not {"SE", "data_iniSE", "municipio_geocodigo"} & set(records[0])
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_public_alert_city_service_serializes_all_mapped_fields(
+    public_historical_alert_tables,
+):
+    alert = LegacyHistoricalAlertDengue.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        estimated_cases=10.5,
+        estimated_cases_min=8,
+        estimated_cases_max=13,
+        cases=3,
+        municipality_geocode=3304557,
+        municipality_name="Rio de Janeiro",
+        rt1_probability=0.9,
+        incidence_100k_probability=0.8,
+        locality_id=1,
+        alert_level=2,
+        model_version="v1",
+        reproduction_number=1.2,
+        population=6200000,
+        temperature_min=20.1,
+        temperature_mean=25.2,
+        temperature_max=30.3,
+        humidity_min=40.1,
+        humidity_mean=55.2,
+        humidity_max=70.3,
+        receptive=1,
+        transmission=1,
+        incidence_level=3,
+        probable_cases=4,
+        estimated_probable_cases=5.5,
+        estimated_probable_cases_min=4,
+        estimated_probable_cases_max=6,
+        confirmed_cases=2,
+    )
+
+    record = get_public_alert_city_records(
+        disease="dengue", geocode=3304557, ew_start=None, ew_end=None
+    )[0]
+
+    assert record == {
+        "epidemiological_week_start_date": "2026-01-04T00:00:00",
+        "epidemiological_week": 202601,
+        "estimated_cases": 10.5,
+        "estimated_cases_min": 8,
+        "estimated_cases_max": 13,
+        "cases": 3,
+        "municipality_geocode": 3304557,
+        "municipality_name": "Rio de Janeiro",
+        "rt1_probability": 0.9,
+        "incidence_100k_probability": 0.8,
+        "locality_id": 1,
+        "alert_level": 2,
+        "id": alert.id,
+        "model_version": "v1",
+        "reproduction_number": 1.2,
+        "population": 6200000,
+        "temperature_min": 20.1,
+        "temperature_mean": 25.2,
+        "temperature_max": 30.3,
+        "humidity_min": 40.1,
+        "humidity_mean": 55.2,
+        "humidity_max": 70.3,
+        "receptive": 1,
+        "transmission": 1,
+        "incidence_level": 3,
+        "probable_cases": 4,
+        "estimated_probable_cases": 5.5,
+        "estimated_probable_cases_min": 4,
+        "estimated_probable_cases_max": 6,
+        "confirmed_cases": 2,
+        "notifications_accumulated_year": None,
+    }
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_public_alert_city_route_reads_inserted_orm_record(
+    public_historical_alert_tables,
+):
+    LegacyHistoricalAlertDengue.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=3304557,
+    )
+
+    response = APIClient().get(
+        reverse("api:v1:alert_city"),
+        {"disease": "dengue", "geocode": 3304557},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"][0]["municipality_geocode"] == 3304557
 
 
 def test_v1_and_legacy_routes_resolve():

--- a/AlertaDengue/tests/dados/test_unmanaged_models.py
+++ b/AlertaDengue/tests/dados/test_unmanaged_models.py
@@ -59,6 +59,17 @@ def test_historical_alert_column_mappings(model):
         model._meta.get_field("municipality_geocode").column
         == "municipio_geocodigo"
     )
+    assert model._meta.get_field("reproduction_number").column == "Rt"
+    assert model._meta.get_field("population").column == "pop"
+    assert model._meta.get_field("temperature_min").column == "tempmin"
+    assert model._meta.get_field("temperature_mean").column == "tempmed"
+    assert model._meta.get_field("temperature_max").column == "tempmax"
+    assert model._meta.get_field("humidity_min").column == "umidmin"
+    assert model._meta.get_field("humidity_mean").column == "umidmed"
+    assert model._meta.get_field("humidity_max").column == "umidmax"
+    assert model._meta.get_field("receptive").column == "receptivo"
+    assert model._meta.get_field("transmission").column == "transmissao"
+    assert model._meta.get_field("incidence_level").column == "nivel_inc"
 
 
 @pytest.mark.parametrize(

--- a/docs/api/historical_alert_service.md
+++ b/docs/api/historical_alert_service.md
@@ -31,12 +31,16 @@ those paths are benchmarked. It introduces no migrations, production database
 connections, SQL writes, or physical database changes.
 
 Internal historical access and small lookups such as
-`dados.dbdata.get_last_SE` use the ORM-backed adapter service. The legacy
-`/api/alertcity/` implementation remains unchanged and uses `AlertCity.search`
-for its compatibility response. Public v1 alert-city has a dedicated service
-boundary that keeps `AlertCity.search`, because its legacy DataFrame shape
-supplies weather, population, receptivity/transmission/incidence, and
-accumulated-notification fields unavailable from historical ORM adapters.
+`dados.dbdata.get_last_SE` use the ORM-backed adapter service. Public
+`/api/v1/alert-city/` also uses the historical-alert service and the unmanaged
+Municipio adapters, then serializes their rows into the normalized public v1
+contract. The legacy `/api/alertcity/` implementation remains unchanged and
+uses `AlertCity.search` for its compatibility response. The adapters remain
+unmanaged; this change introduces no physical database schema change (and any
+Django migration needed for adapter state is state-only).
+`notifications_accumulated_year` remains a public v1 field, but is not mapped
+to these adapters because the retained tables have no `notif_accum_year`
+column; ORM-backed records therefore return it as `null`.
 
 Report, dashboard, and geofile SQL remain explicit exceptions because they
 require joins, window functions, or legacy DataFrame-shaped results.

--- a/docs/api/public_rest_v1.md
+++ b/docs/api/public_rest_v1.md
@@ -62,8 +62,10 @@ the following normalized public v1 fields when available from the query result:
 contract are omitted. Fields in the contract with a missing, `NaN`, or `NaT`
 source value may be returned as `null`. Physical database columns are unchanged;
 normalization occurs in the dedicated public v1 alert-city service boundary.
-That service preserves the normalized public v1 response contract while it
-continues to use `AlertCity.search` as its data boundary: weather,
-receptivity/transmission/incidence indicators, population, and accumulated
-notification fields are not all available from the historical-alert ORM adapters
-alone.
+That service reads the retained Municipio historical-alert tables through the
+historical-alert service and unmanaged ORM adapters. The normalized public v1
+response contract is unchanged, while legacy `/api/alertcity/` remains on its
+existing compatibility implementation. No physical database schema change was
+introduced. `notifications_accumulated_year` remains in the public v1 contract,
+but is `null` on the ORM-backed path because `notif_accum_year` is absent from
+the retained Municipio historical-alert tables.


### PR DESCRIPTION
## Description

Completes the remaining work for #1077 by routing public `/api/v1/alert-city/` data access through the historical-alert service and unmanaged Municipio ORM adapters.

This builds on #1078, which isolated the public v1 alert-city service boundary.

### Changes

- route `/api/v1/alert-city/` through the historical-alert service;
- add ORM-backed query builder for historical alert records;
- extend unmanaged Municipio historical-alert adapters with the remaining public v1 fields;
- serialize ORM rows into the existing public v1 response contract;
- preserve `epidemiological_week_start_date` as the existing public v1 datetime string format;
- keep legacy `/api/alertcity/` unchanged;
- update API/service documentation;
- add real ORM-backed tests without `MagicMock` or `monkeypatch`.


### Notes

No physical database schema change was introduced.

No migration was needed.

Legacy `/api/alertcity/` remains unchanged.

Closes #1077.