### PR TITLE
refactor(database): migrate Dengue_global lookups to ORM

### DIFF
--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
 from datetime import datetime
 import logging
 from typing import (
@@ -28,6 +27,14 @@ from sqlalchemy.engine import Engine, Row
 
 # local
 from .episem import episem
+from .services.dengue_global_lookups import (
+    CID10_CODES as CID10,
+    ReportParameters,
+    get_cities as get_dengue_global_cities,
+    get_regional_municipalities,
+    get_regional_names as get_dengue_global_regional_names,
+    get_report_parameters as get_dengue_global_report_parameters,
+)
 from .services.historical_alerts import get_latest_historical_alert_week
 
 logger = logging.getLogger(__name__)
@@ -39,7 +46,6 @@ QUERY_CACHE_TIMEOUT = getattr(settings, "QUERY_CACHE_TIMEOUT")
 
 T = TypeVar("T")
 
-CID10 = {"dengue": "A90", "chikungunya": "A92.0", "zika": "A928"}
 DISEASES_SHORT = ["dengue", "chik", "zika"]
 DISEASES_NAME = CID10.keys()
 ALERT_COLOR = {1: "verde", 2: "amarelo", 3: "laranja", 4: "vermelho"}
@@ -71,21 +77,6 @@ def _build_monitored_municipalities_cache_key(
         else _normalize_cache_key_component(state_name)
     )
     return f"count_monitored_municipalities:{state_component}:{disease}"
-
-
-@dataclass(frozen=True, slots=True)
-class ReportParameters:
-    """Disease-specific parameters used by city reports."""
-
-    cid10: str
-    municipio_geocodigo: int
-    varcli: Any
-    clicrit: Any
-    varcli2: Any
-    clicrit2: Any
-    limiar_preseason: Any
-    limiar_posseason: Any
-    limiar_epidemico: Any
 
 
 UF_CODES = {
@@ -239,9 +230,7 @@ def count_monitored_municipalities(
 
 
 class RegionalParameters:
-    """Helpers to query regional parameters via SQL."""
-
-    SCHEMA: str = "Dengue_global"
+    """Compatibility facade for Django ORM Dengue_global lookup services."""
 
     @classmethod
     def get_regional_names(cls, state_name: str) -> list[str]:
@@ -258,28 +247,7 @@ class RegionalParameters:
         list[str]
             Regional names.
         """
-        cache_name = f"regional_names_to_{state_name.replace(' ', '_')}"
-        cached = cache.get(cache_name)
-        if cached is not None:
-            return cached
-
-        sql = f"""
-            SELECT DISTINCT r.nome
-            FROM "{cls.SCHEMA}"."regional" AS r
-            JOIN "{cls.SCHEMA}"."Municipio" AS m ON r.id = m.id_regional
-            JOIN "{cls.SCHEMA}"."parameters" AS p ON m.geocodigo = p.municipio_geocodigo
-            WHERE m.uf = :state_name
-        """
-
-        df = _read_sql_df(
-            DB_ENGINE,
-            sql,
-            params={"state_name": state_name},
-        )
-
-        res = df["nome"].tolist()
-        cache.set(cache_name, res, QUERY_CACHE_TIMEOUT)
-        return res
+        return get_dengue_global_regional_names(state_name)
 
     @classmethod
     def get_cities(
@@ -290,100 +258,14 @@ class RegionalParameters:
         """
         Return mapping geocode -> city name for a region or state.
         """
-        cities_by_region: dict[int, str] = {}
-        if state_name is None:
-            return cities_by_region
-
-        if regional_name is not None:
-            cache_name = (
-                f"{regional_name.replace(' ', '_')}_"
-                f"{state_name.replace(' ', '_')}"
-            )
-            cached = cache.get(cache_name)
-            if cached is not None:
-                return cached
-
-            sql = f"""
-                SELECT DISTINCT m.geocodigo, m.nome
-                FROM "{cls.SCHEMA}"."Municipio" AS m
-                JOIN "{cls.SCHEMA}"."regional" AS r ON m.id_regional = r.id
-                JOIN "{cls.SCHEMA}"."parameters" AS p ON m.geocodigo = p.municipio_geocodigo
-                WHERE m.uf = :state_name AND r.nome = :regional_name
-                ORDER BY m.nome
-            """
-
-            df = _read_sql_df(
-                DB_ENGINE,
-                sql,
-                params={
-                    "state_name": state_name,
-                    "regional_name": regional_name,
-                },
-            )
-
-            for row in df.itertuples(index=False):
-                cities_by_region[int(row.geocodigo)] = str(row.nome)
-
-            cache.set(cache_name, cities_by_region, QUERY_CACHE_TIMEOUT)
-            return cities_by_region
-
-        cache_name = f"all_cities_from_{state_name.replace(' ', '_')}"
-        cached = cache.get(cache_name)
-        if cached is not None:
-            return cached
-
-        sql = f"""
-            SELECT geocodigo, nome
-            FROM "{cls.SCHEMA}"."Municipio"
-            WHERE uf = :state_name
-            ORDER BY nome
-        """
-
-        df = _read_sql_df(
-            DB_ENGINE,
-            sql,
-            params={"state_name": state_name},
-        )
-
-        for row in df.itertuples(index=False):
-            cities_by_region[int(row.geocodigo)] = str(row.nome)
-
-        cache.set(cache_name, cities_by_region, QUERY_CACHE_TIMEOUT)
-        return cities_by_region
+        return get_dengue_global_cities(regional_name, state_name)
 
     @classmethod
     def get_report_parameters(
         cls, geocode: int, disease: str
     ) -> ReportParameters | None:
         """Return disease-specific parameters used by city reports."""
-        cid10_code = CID10.get(disease, "")
-
-        sql = f"""
-            SELECT
-                cid10,
-                municipio_geocodigo,
-                varcli,
-                clicrit,
-                varcli2,
-                clicrit2,
-                limiar_preseason,
-                limiar_posseason,
-                limiar_epidemico
-            FROM "{cls.SCHEMA}"."parameters"
-            WHERE cid10 = :cid10_code
-              AND municipio_geocodigo = :geocode
-        """
-
-        df = _read_sql_df(
-            DB_ENGINE,
-            sql,
-            params={"cid10_code": cid10_code, "geocode": geocode},
-        )
-
-        if df.empty:
-            return None
-
-        return ReportParameters(**df.iloc[0].to_dict())
+        return get_dengue_global_report_parameters(geocode, disease)
 
 
 # General util functions
@@ -1013,22 +895,19 @@ class ReportState:
         res = cache.get(cache_name)
 
         if res is None:
-            uf_name = ALL_STATE_NAMES[state][0]
+            uf_name = str(ALL_STATE_NAMES[state][0])
 
-            sql = """
-                SELECT
-                    m.id_regional AS id_regional,
-                    m.regional AS nome_regional,
-                    m.geocodigo AS municipio_geocodigo,
-                    m.nome AS municipio_nome
-                FROM "Dengue_global"."Municipio" AS m
-                WHERE m.uf = :uf_name
-            """
-
-            df = _read_sql_df(
-                DB_ENGINE,
-                sql,
-                params={"uf_name": uf_name},
+            rows = get_regional_municipalities(uf_name)
+            df = pd.DataFrame.from_records(
+                rows,
+                columns=["regional_id", "regional_name", "geocode", "name"],
+            ).rename(
+                columns={
+                    "regional_id": "id_regional",
+                    "regional_name": "nome_regional",
+                    "geocode": "municipio_geocodigo",
+                    "name": "municipio_nome",
+                }
             )
 
             res = df

--- a/AlertaDengue/dados/models/dengue_global.py
+++ b/AlertaDengue/dados/models/dengue_global.py
@@ -118,9 +118,13 @@ class Parameter(models.Model):
     pk = models.CompositePrimaryKey("municipality_geocode", "cid10_code")
     municipality_geocode = models.IntegerField(db_column="municipio_geocodigo")
     cid10_code = models.CharField(db_column="cid10", max_length=16)
-    baseline_variation = models.FloatField(db_column="varcli", null=True)
+    baseline_variation = models.CharField(
+        db_column="varcli", max_length=128, null=True
+    )
     baseline_critical = models.FloatField(db_column="clicrit", null=True)
-    secondary_variation = models.FloatField(db_column="varcli2", null=True)
+    secondary_variation = models.CharField(
+        db_column="varcli2", max_length=128, null=True
+    )
     secondary_critical = models.FloatField(db_column="clicrit2", null=True)
     preseason_threshold = models.FloatField(
         db_column="limiar_preseason", null=True

--- a/AlertaDengue/dados/services/dengue_global_lookups.py
+++ b/AlertaDengue/dados/services/dengue_global_lookups.py
@@ -1,0 +1,164 @@
+"""Read-only Django ORM lookups for retained ``Dengue_global`` objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.core.cache import cache
+from django.db.models import Exists, OuterRef
+
+from ad_main.typed_settings import get_query_cache_timeout
+from dados.models import City, Parameter, Regional
+
+CID10_CODES = {"dengue": "A90", "chikungunya": "A92.0", "zika": "A928"}
+
+
+@dataclass(frozen=True, slots=True)
+class ReportParameters:
+    """Disease-specific parameters used by city reports."""
+
+    cid10: str
+    municipio_geocodigo: int
+    varcli: Any
+    clicrit: Any
+    varcli2: Any
+    clicrit2: Any
+    limiar_preseason: Any
+    limiar_posseason: Any
+    limiar_epidemico: Any
+
+
+def get_regional_names(state_name: str) -> list[str]:
+    """Return parameterized regional names for a state.
+
+    Parameters
+    ----------
+    state_name
+        State name used by the retained municipality table.
+    """
+    cache_name = f"regional_names_to_{state_name.replace(' ', '_')}"
+    cached = cache.get(cache_name)
+    if cached is not None:
+        return cached
+
+    parameterized_cities = Parameter.objects.filter(
+        municipality_geocode=OuterRef("geocode")
+    )
+    regional_ids = (
+        City.objects.filter(state=state_name)
+        .filter(Exists(parameterized_cities))
+        .values("regional_id")
+    )
+    names = list(
+        Regional.objects.filter(id__in=regional_ids)
+        .order_by("name")
+        .values_list("name", flat=True)
+    )
+    cache.set(cache_name, names, get_query_cache_timeout())
+    return names
+
+
+def get_cities(
+    regional_name: str | None = None,
+    state_name: str | None = None,
+) -> dict[int, str]:
+    """Return a name-ordered mapping of municipality geocodes to names."""
+    if state_name is None:
+        return {}
+
+    if regional_name is None:
+        cache_name = f"all_cities_from_{state_name.replace(' ', '_')}"
+        queryset = City.objects.filter(state=state_name)
+    else:
+        cache_name = (
+            f"{regional_name.replace(' ', '_')}_{state_name.replace(' ', '_')}"
+        )
+        parameterized_cities = Parameter.objects.filter(
+            municipality_geocode=OuterRef("geocode")
+        )
+        regional_ids = Regional.objects.filter(name=regional_name).values("id")
+        queryset = City.objects.filter(
+            state=state_name, regional_id__in=regional_ids
+        ).filter(Exists(parameterized_cities))
+
+    cached = cache.get(cache_name)
+    if cached is not None:
+        return cached
+
+    cities = {
+        int(geocode): str(name)
+        for geocode, name in queryset.order_by("name").values_list(
+            "geocode", "name"
+        )
+    }
+    cache.set(cache_name, cities, get_query_cache_timeout())
+    return cities
+
+
+def get_report_parameters(
+    municipality_geocode: int, disease: str
+) -> ReportParameters | None:
+    """Return one city/disease parameter record using both key components.
+
+    Parameters
+    ----------
+    municipality_geocode
+        IBGE municipality geocode.
+    disease
+        Supported normalized disease name.
+    """
+    cid10_code = CID10_CODES.get(disease)
+    if cid10_code is None:
+        return None
+
+    record = (
+        Parameter.objects.filter(
+            municipality_geocode=municipality_geocode,
+            cid10_code=cid10_code,
+        )
+        .values(
+            "cid10_code",
+            "municipality_geocode",
+            "baseline_variation",
+            "baseline_critical",
+            "secondary_variation",
+            "secondary_critical",
+            "preseason_threshold",
+            "postseason_threshold",
+            "epidemic_threshold",
+        )
+        .first()
+    )
+    if record is None:
+        return None
+
+    return ReportParameters(
+        cid10=str(record["cid10_code"]),
+        municipio_geocodigo=int(record["municipality_geocode"]),
+        varcli=record["baseline_variation"],
+        clicrit=record["baseline_critical"],
+        varcli2=record["secondary_variation"],
+        clicrit2=record["secondary_critical"],
+        limiar_preseason=record["preseason_threshold"],
+        limiar_posseason=record["postseason_threshold"],
+        limiar_epidemico=record["epidemic_threshold"],
+    )
+
+
+def get_regional_municipalities(state_name: str) -> list[dict[str, Any]]:
+    """Return stable regional-report rows for a state.
+
+    The serialized rows let the legacy report adapter retain its DataFrame
+    output without caching a lazy queryset.
+    """
+    return list(
+        City.objects.filter(state=state_name)
+        .order_by("geocode")
+        .values(
+            "regional_id",
+            "regional_name",
+            "geocode",
+            "name",
+        )
+    )

--- a/AlertaDengue/tests/dados/dbdata/conftest.py
+++ b/AlertaDengue/tests/dados/dbdata/conftest.py
@@ -111,16 +111,16 @@ def regional_parameters_tables(db_engine: Engine) -> Iterator[None]:
             text(
                 f"""
             CREATE TABLE "{schema}"."parameters" (
-                id SERIAL PRIMARY KEY,
-                municipio_geocodigo BIGINT,
-                cid10 TEXT,
+                municipio_geocodigo BIGINT NOT NULL,
+                cid10 TEXT NOT NULL,
                 varcli TEXT,
                 clicrit NUMERIC,
                 varcli2 TEXT,
                 clicrit2 NUMERIC,
                 limiar_preseason NUMERIC,
                 limiar_posseason NUMERIC,
-                limiar_epidemico NUMERIC
+                limiar_epidemico NUMERIC,
+                PRIMARY KEY (municipio_geocodigo, cid10)
             )
         """
             )
@@ -146,7 +146,8 @@ def regional_parameters_tables(db_engine: Engine) -> Iterator[None]:
                 f"""
             INSERT INTO "{schema}"."Municipio" (geocodigo, nome, uf, id_regional) VALUES
             (3304557, 'Rio de Janeiro', 'RJ', 1),
-            (3303302, 'Niterói', 'RJ', 2)
+            (3303302, 'Niterói', 'RJ', 2),
+            (3301702, 'No parameters city', 'RJ', 1)
         """
             )
         )

--- a/AlertaDengue/tests/dados/dbdata/test_regional_parameters.py
+++ b/AlertaDengue/tests/dados/dbdata/test_regional_parameters.py
@@ -11,8 +11,17 @@ from django.core.cache import cache
 import pytest
 
 from dados.dbdata import RegionalParameters
+from dados.models import City
+from dados.services.dengue_global_lookups import (
+    get_cities,
+    get_regional_names,
+    get_report_parameters,
+)
 
-pytestmark = pytest.mark.usefixtures("regional_parameters_tables")
+pytestmark = [
+    pytest.mark.django_db(databases={"default", "dados"}, transaction=True),
+    pytest.mark.usefixtures("regional_parameters_tables"),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -26,6 +35,7 @@ def test_get_regional_names() -> None:
     assert "Metropolitana I" in names
     assert "Metropolitana II" in names
     assert len(names) == 2
+    assert names == sorted(names)
 
 
 def test_get_cities_by_state() -> None:
@@ -35,6 +45,7 @@ def test_get_cities_by_state() -> None:
     assert cities[3304557] == "Rio de Janeiro"
     assert 3303302 in cities
     assert cities[3303302] == "Niterói"
+    assert cities[3301702] == "No parameters city"
 
 
 def test_get_cities_by_region() -> None:
@@ -44,6 +55,25 @@ def test_get_cities_by_region() -> None:
     )
     assert 3304557 in cities  # Rio is in Metro I
     assert 3303302 not in cities  # Niteroi is in Metro II (in our mock data)
+    assert 3301702 not in cities  # This city has no parameters.
+
+
+def test_lookup_service_matches_legacy_sql_contracts() -> None:
+    """ORM lookup values preserve the former SQL consumer contracts."""
+    assert get_regional_names("RJ") == [
+        "Metropolitana I",
+        "Metropolitana II",
+    ]
+    cities = get_cities(state_name="RJ")
+    assert list(cities.items()) == [
+        (3303302, "Niterói"),
+        (3301702, "No parameters city"),
+        (3304557, "Rio de Janeiro"),
+    ]
+    assert cache.get("all_cities_from_RJ") == cities
+    assert City.objects.all().db == "dados"
+    assert get_cities("Metropolitana I", "RJ") == {3304557: "Rio de Janeiro"}
+    assert get_cities(state_name="SP") == {}
 
 
 def test_get_report_parameters() -> None:
@@ -56,6 +86,7 @@ def test_get_report_parameters() -> None:
     assert params.varcli2 == "temp_min"
     assert params.limiar_preseason == 100
     assert params.limiar_epidemico == 300
+    assert get_report_parameters(3304557, "dengue") == params
 
 
 class TestDiseaseFilterParameters:
@@ -90,6 +121,10 @@ class TestDiseaseFilterParameters:
         assert (
             RegionalParameters.get_report_parameters(3304557, "zika") is None
         )
+        assert (
+            RegionalParameters.get_report_parameters(3304557, "yellow-fever")
+            is None
+        )
 
     def test_regional_names_not_duplicated(self) -> None:
         assert len(RegionalParameters.get_regional_names("RJ")) == 2
@@ -97,6 +132,6 @@ class TestDiseaseFilterParameters:
     def test_cities_not_duplicated(self) -> None:
         cities = RegionalParameters.get_cities(state_name="RJ")
 
-        assert len(cities) == 2
+        assert len(cities) == 3
         assert 3304557 in cities
         assert 3303302 in cities

--- a/AlertaDengue/tests/dados/dbdata/test_report_state.py
+++ b/AlertaDengue/tests/dados/dbdata/test_report_state.py
@@ -8,8 +8,12 @@ from django.core.cache import cache
 import pytest
 
 from dados.dbdata import ReportState
+from dados.services.dengue_global_lookups import get_regional_municipalities
 
-pytestmark = pytest.mark.usefixtures("report_data_tables")
+pytestmark = [
+    pytest.mark.django_db(databases={"default", "dados"}, transaction=True),
+    pytest.mark.usefixtures("report_data_tables"),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +40,20 @@ def test_get_regional_by_state() -> None:
     assert row["municipio_geocodigo"] == 3304557
     assert row["municipio_nome"] == "Rio de Janeiro"
     assert row["id_regional"] == 1
+    assert list(df.columns) == [
+        "id_regional",
+        "nome_regional",
+        "municipio_geocodigo",
+        "municipio_nome",
+    ]
+    assert get_regional_municipalities("Rio de Janeiro") == [
+        {
+            "regional_id": 1,
+            "regional_name": "Metropolitana I",
+            "geocode": 3304557,
+            "name": "Rio de Janeiro",
+        }
+    ]
 
 
 def test_create_report_state_data() -> None:

--- a/AlertaDengue/tests/dados/test_tasks.py
+++ b/AlertaDengue/tests/dados/test_tasks.py
@@ -39,10 +39,30 @@ def db_engine() -> Engine:
 
 @pytest.fixture()
 def episcanner_data_tables(db_engine: Engine) -> Iterator[None]:
+    """Provision the external tables used by EpiScanner task tests."""
     all_geocodes = [gc for uf in CITIES.values() for gc in uf["geocodes"]]
 
     with db_engine.begin() as conn:
         conn.execute(text('CREATE SCHEMA IF NOT EXISTS "Municipio"'))
+        conn.execute(text('CREATE SCHEMA IF NOT EXISTS "Dengue_global"'))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS "Dengue_global"."Municipio" (
+                    geocodigo BIGINT PRIMARY KEY,
+                    nome TEXT,
+                    uf TEXT
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                'ALTER TABLE "Dengue_global"."Municipio" '
+                "ADD COLUMN IF NOT EXISTS nome TEXT, "
+                "ADD COLUMN IF NOT EXISTS uf TEXT"
+            )
+        )
 
         for suffix in ["", "_chik", "_zika"]:
             table_name = f"Historico_alerta{suffix}"
@@ -102,13 +122,6 @@ def episcanner_data_tables(db_engine: Engine) -> Iterator[None]:
             _insert_data("_chik", gc, base * 0.5)
             _insert_data("_zika", gc, base * 0.3)
 
-        conn.execute(
-            text(
-                'ALTER TABLE "Dengue_global"."Municipio" '
-                "ADD COLUMN IF NOT EXISTS nome TEXT, "
-                "ADD COLUMN IF NOT EXISTS uf TEXT"
-            )
-        )
         for uf_abbr, info in CITIES.items():
             for gc in info["geocodes"]:
                 conn.execute(
@@ -128,16 +141,36 @@ def episcanner_data_tables(db_engine: Engine) -> Iterator[None]:
         conn.execute(text('DROP SCHEMA IF EXISTS "Municipio" CASCADE'))
         for uf_info in CITIES.values():
             for gc in uf_info["geocodes"]:
-                try:
-                    conn.execute(
-                        text(
-                            'DELETE FROM "Dengue_global"."Municipio" '
-                            "WHERE geocodigo = :gc"
-                        ),
-                        {"gc": gc},
+                conn.execute(
+                    text(
+                        'DELETE FROM "Dengue_global"."Municipio" '
+                        "WHERE geocodigo = :gc"
+                    ),
+                    {"gc": gc},
+                )
+
+
+class TestEpiscannerTaskFixture:
+    @pytest.mark.django_db(transaction=True, databases={"default", "dados"})
+    def test_provisions_required_dengue_global_municipio_table(
+        self, db_engine: Engine, episcanner_data_tables: None
+    ) -> None:
+        """The task fixture owns its external municipality-table dependency."""
+        with db_engine.connect() as conn:
+            columns = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT column_name
+                        FROM information_schema.columns
+                        WHERE table_schema = 'Dengue_global'
+                          AND table_name = 'Municipio'
+                        """
                     )
-                except Exception:
-                    pass
+                ).scalars()
+            )
+
+        assert {"geocodigo", "nome", "uf"} <= columns
 
 
 @pytest.fixture()

--- a/AlertaDengue/tests/dados/test_unmanaged_models.py
+++ b/AlertaDengue/tests/dados/test_unmanaged_models.py
@@ -132,6 +132,22 @@ def test_notification_key_column_mappings():
     )
 
 
+def test_dengue_global_lookup_adapter_metadata():
+    assert City._meta.get_field("geocode").column == "geocodigo"
+    assert City._meta.get_field("state").column == "uf"
+    assert City._meta.get_field("regional_id").column == "id_regional"
+    assert Regional._meta.get_field("id").primary_key
+    assert Regional._meta.get_field("macroregion").column == "id_macroregional"
+    assert Parameter._meta.get_field("municipality_geocode").column == (
+        "municipio_geocodigo"
+    )
+    assert Parameter._meta.get_field("cid10_code").column == "cid10"
+    assert Parameter._meta.pk.field_names == (
+        "municipality_geocode",
+        "cid10_code",
+    )
+
+
 def test_supported_historical_alert_diseases_are_canonical():
     assert get_supported_historical_alert_diseases() == (
         "dengue",

--- a/docs/database/orm_unmanaged_models.md
+++ b/docs/database/orm_unmanaged_models.md
@@ -9,7 +9,7 @@ quoted identifiers remain only in db_table and db_column mappings.
 
 | Schema | Responsibility | Ownership | Refactor status |
 | --- | --- | --- | --- |
-| Dengue_global | Municipality, disease, regional and parameter lookups | Retained external/read-only | Lookup boundary is next |
+| Dengue_global | Municipality, disease, regional and parameter lookups | Retained external/read-only | Search/report lookup boundary complete |
 | Municipio | Historical alerts and notifications | Alerts external; notifications application-written through ingestion | Historical API complete |
 | ingestion | SINAN run, stage and rollback control | Django-managed | Current model boundary retained |
 | episcanner | Scan-result parameters | Django-managed | Current model boundary retained |
@@ -21,12 +21,12 @@ quoted identifiers remain only in db_table and db_column mappings.
 
 | Object | Type | Django model | Management | Access | Current responsibility | Next action |
 | --- | --- | --- | --- | --- | --- | --- |
-| Municipio | table | dados.models.City | Unmanaged | Read-only | Municipality lookup, report and map metadata | Confirm retained geo fields and ownership; consolidate lookup reads |
+| Municipio | table | dados.models.City | Unmanaged | Read-only | Municipality search/report lookup and map metadata | Search/report reads use the shared ORM service; retain map metadata review |
 | CID10 | table | dados.models.CID10 | Unmanaged | Read-only | Disease-code lookup | Retain adapter |
 | "Dengue_global"."estado" | table | dados.models.State | Unmanaged | Read-only | State-history dependency | Keep in lookup review |
 | "Dengue_global"."macroregional" | table | dados.models.MacroRegion | Unmanaged | Read-only | Regional relationship | Keep in lookup review |
-| regional | table | dados.models.Regional | Unmanaged | Read-only | Regional search/report lookup | Shared lookup service |
-| parameters | table | dados.models.Parameter | Unmanaged | Read-only | City/disease report thresholds; logical key (municipio_geocodigo, cid10) | Confirm composite-key representation and consolidate lookup reads; do not introduce a surrogate key |
+| regional | table | dados.models.Regional | Unmanaged | Read-only | Regional search/report lookup | Shared ORM lookup service |
+| parameters | table | dados.models.Parameter | Unmanaged | Read-only | City/disease report thresholds; logical key (municipio_geocodigo, cid10) | Shared ORM lookup service; every parameter read filters both key components; no surrogate key |
 | "Dengue_global"."parameters_uf" | table | dados.models.ParameterUF | Managed | Django migration-owned | UF-level thresholds | Retain current model |
 
 ### Municipio
@@ -67,16 +67,12 @@ explicit SQL compatibility path and is not a target of this sequence.
 
 ## Next schema-group refactors
 
-1. **Dengue_global lookup and parameter reads.** Include Municipio, regional
-   and parameters behind a shared typed service for search/report lookups.
-   Prerequisite: read-only confirmation of City columns, keys, external writers
-   and ownership. Exclude maps/geofiles until geo fields are verified.
-2. **Municipio.Notificacao internal list.** Use the existing adapter for
+1. **Municipio.Notificacao internal list.** Use the existing adapter for
    bounded internal filtering/pagination. Exclude CSV analytics and ingestion.
-3. **Bounded Municipio.Historico_alerta city reports.** Proceed only after
+2. **Bounded Municipio.Historico_alerta city reports.** Proceed only after
    output and performance equivalence are demonstrated. Exclude state
    dashboards and compatibility APIs.
-4. **Dengue_global.Municipio map/geofile metadata.** Add only verified adapter
+3. **Dengue_global.Municipio map/geofile metadata.** Add only verified adapter
    metadata and a focused service boundary. Exclude geometry and file workflow
    redesign.
 


### PR DESCRIPTION
## Description

- Replace raw SQL for `Dengue_global` regional, municipality, and parameter lookups with a shared ORM service.
- Preserve legacy return structures, cache keys, timeout behavior, and database routing.
- Keep state-only municipality lookup behavior while requiring parameters for regional filtering.
- Align unmanaged parameter fields with the physical database schema.
- Add PostgreSQL-backed compatibility tests and update the ORM audit documentation.

Closes #1082