### PR TITLE
refactor(database): migrate bounded historical alerts to ORM

### DIFF
--- a/AlertaDengue/dados/dbdata.py
+++ b/AlertaDengue/dados/dbdata.py
@@ -35,7 +35,10 @@ from .services.dengue_global_lookups import (
     get_regional_names as get_dengue_global_regional_names,
     get_report_parameters as get_dengue_global_report_parameters,
 )
-from .services.historical_alerts import get_latest_historical_alert_week
+from .services.historical_alerts import (
+    build_report_city_historical_alert_queryset,
+    get_latest_historical_alert_week,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -824,12 +827,6 @@ class ReportCity:
         if disease not in CID10:
             raise ValueError(f"Unsupported disease: {disease!r}")
 
-        table_suffix = ""
-        if disease != "dengue":
-            table_suffix = get_disease_suffix(disease)
-
-        table_name = f"Historico_alerta{table_suffix}"
-
         ew_end = year_week
         ew_start = ew_end - 200
 
@@ -837,43 +834,44 @@ class ReportCity:
         # (e.g. 202401 - 200 = 202201) works roughly but isn't chemically pure date math.
         # However, preserving the logic from original code: `ew_start = ew_end - 200`
 
-        sql = f"""
-            SELECT
-                "SE" AS "SE",
-                casos AS "casos notif.",
-                casos_est AS "casos_est",
-                p_inc100k AS "incidência",
-                p_rt1 AS "pr(incid. subir)",
-                tempmin AS "temp.min",
-                tempmed AS "temp.med",
-                tempmax AS "temp.max",
-                umidmin AS "umid.min",
-                umidmed AS "umid.med",
-                umidmax AS "umid.max",
-                CASE
-                    WHEN nivel = 1 THEN 'verde'
-                    WHEN nivel = 2 THEN 'amarelo'
-                    WHEN nivel = 3 THEN 'laranja'
-                    WHEN nivel = 4 THEN 'vermelho'
-                    ELSE '-'
-                END AS nivel,
-                nivel AS level_code
-            FROM "Municipio"."{table_name}"
-            WHERE
-                "SE" BETWEEN :ew_start AND :ew_end
-                AND municipio_geocodigo = :geocode
-            ORDER BY "SE"
-            LIMIT 200
-        """
-
-        df = _read_sql_df(
-            DB_ENGINE,
-            sql,
-            params={
-                "ew_start": ew_start,
-                "ew_end": ew_end,
-                "geocode": geocode,
-            },
+        rows = build_report_city_historical_alert_queryset(
+            disease=disease,
+            municipality_geocode=geocode,
+            start_week=ew_start,
+            end_week=ew_end,
+        )
+        df = pd.DataFrame.from_records(
+            rows,
+            columns=[
+                "report_week",
+                "notified_cases",
+                "estimated_cases",
+                "incidence",
+                "incidence_rise_probability",
+                "minimum_temperature",
+                "mean_temperature",
+                "maximum_temperature",
+                "minimum_humidity",
+                "mean_humidity",
+                "maximum_humidity",
+                "alert_label",
+                "level_code",
+            ],
+        ).rename(
+            columns={
+                "report_week": "SE",
+                "notified_cases": "casos notif.",
+                "estimated_cases": "casos_est",
+                "incidence": "incidência",
+                "incidence_rise_probability": "pr(incid. subir)",
+                "minimum_temperature": "temp.min",
+                "mean_temperature": "temp.med",
+                "maximum_temperature": "temp.max",
+                "minimum_humidity": "umid.min",
+                "mean_humidity": "umid.med",
+                "maximum_humidity": "umid.max",
+                "alert_label": "nivel",
+            }
         )
         return df.set_index("SE")
 

--- a/AlertaDengue/dados/services/historical_alerts.py
+++ b/AlertaDengue/dados/services/historical_alerts.py
@@ -1,5 +1,7 @@
 """Lookup helpers for the separate legacy historical-alert adapters."""
 
+from django.db.models import Case, CharField, F, QuerySet, Value, When
+
 from dados.models.municipio import (
     LegacyHistoricalAlertChikungunya,
     LegacyHistoricalAlertDengue,
@@ -55,6 +57,67 @@ def build_historical_alert_records_queryset(
 
     return queryset.order_by(
         "epidemiological_week_start_date", "epidemiological_week", "id"
+    )
+
+
+def build_report_city_historical_alert_queryset(
+    *,
+    disease: str,
+    municipality_geocode: int,
+    start_week: int,
+    end_week: int,
+) -> QuerySet:
+    """Return the bounded projection used by the city-report charts.
+
+    This preserves the legacy ``ReportCity`` range and 200-row limit while
+    keeping filtering, projection, ordering, and limiting on the ``dados``
+    PostgreSQL connection.
+    """
+    model = get_legacy_historical_alert_model(disease)
+    alert_label = Case(
+        When(alert_level=1, then=Value("verde")),
+        When(alert_level=2, then=Value("amarelo")),
+        When(alert_level=3, then=Value("laranja")),
+        When(alert_level=4, then=Value("vermelho")),
+        default=Value("-"),
+        output_field=CharField(),
+    )
+    return (
+        model.objects.using("dados")
+        .filter(
+            municipality_geocode=municipality_geocode,
+            epidemiological_week__range=(start_week, end_week),
+        )
+        .annotate(
+            report_week=F("epidemiological_week"),
+            notified_cases=F("cases"),
+            incidence=F("incidence_100k_probability"),
+            incidence_rise_probability=F("rt1_probability"),
+            minimum_temperature=F("temperature_min"),
+            mean_temperature=F("temperature_mean"),
+            maximum_temperature=F("temperature_max"),
+            minimum_humidity=F("humidity_min"),
+            mean_humidity=F("humidity_mean"),
+            maximum_humidity=F("humidity_max"),
+            alert_label=alert_label,
+            level_code=F("alert_level"),
+        )
+        .order_by("epidemiological_week")
+        .values(
+            "report_week",
+            "notified_cases",
+            "estimated_cases",
+            "incidence",
+            "incidence_rise_probability",
+            "minimum_temperature",
+            "mean_temperature",
+            "maximum_temperature",
+            "minimum_humidity",
+            "mean_humidity",
+            "maximum_humidity",
+            "alert_label",
+            "level_code",
+        )[:200]
     )
 
 

--- a/AlertaDengue/tests/dados/dbdata/test_report_city.py
+++ b/AlertaDengue/tests/dados/dbdata/test_report_city.py
@@ -5,11 +5,21 @@ Tests for ReportCity class in dbdata.py.
 from __future__ import annotations
 
 from django.core.cache import cache
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+import pandas as pd
 import pytest
+from sqlalchemy import text
 
-from dados.dbdata import ReportCity
+from dados.dbdata import DB_ENGINE, ReportCity
+from dados.services.historical_alerts import (
+    build_report_city_historical_alert_queryset,
+)
 
-pytestmark = pytest.mark.usefixtures("report_data_tables")
+pytestmark = [
+    pytest.mark.usefixtures("report_data_tables"),
+    pytest.mark.django_db(databases={"default", "dados"}, transaction=True),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -78,3 +88,121 @@ def test_read_disease_data_filter_range() -> None:
 
     assert 202401 in df.index
     assert 202402 not in df.index  # 202402 > 202401
+
+
+@pytest.mark.parametrize(
+    ("disease", "table"),
+    [
+        ("dengue", '"Municipio"."Historico_alerta"'),
+        ("chikungunya", '"Municipio"."Historico_alerta_chik"'),
+        ("zika", '"Municipio"."Historico_alerta_zika"'),
+    ],
+)
+def test_report_city_queryset_is_bounded_and_explicitly_routed(
+    disease: str, table: str
+) -> None:
+    queryset = build_report_city_historical_alert_queryset(
+        disease=disease,
+        municipality_geocode=3304557,
+        start_week=202201,
+        end_week=202402,
+    )
+
+    assert queryset._db == "dados"
+    assert queryset.model._meta.db_table == table
+    assert queryset.query.order_by == ("epidemiological_week",)
+    assert queryset.query.low_mark == 0
+    assert queryset.query.high_mark == 200
+
+
+@pytest.mark.parametrize(
+    ("disease", "table"),
+    [
+        ("dengue", "Historico_alerta"),
+        ("chikungunya", "Historico_alerta_chik"),
+        ("zika", "Historico_alerta_zika"),
+    ],
+)
+def test_read_disease_data_matches_legacy_sql_and_uses_dados(
+    disease: str, table: str
+) -> None:
+    """The bounded ORM projection retains the legacy DataFrame contract."""
+    with DB_ENGINE.begin() as connection:
+        connection.execute(
+            text(
+                f'''INSERT INTO "Municipio"."{table}" (
+                    "SE", "data_iniSE", municipio_geocodigo, casos,
+                    casos_est, nivel, p_inc100k, p_rt1, tempmin, tempmed,
+                    tempmax, umidmin, umidmed, umidmax
+                ) VALUES
+                    (202350, '2023-12-11', 3304557, 5, 7, 4, NULL, 0.5,
+                     20.1, NULL, 30.1, 60.1, NULL, 80.1),
+                    (202401, '2024-01-01', 9999999, 99, 99, 1, 1, 1,
+                     1, 1, 1, 1, 1, 1),
+                    (202000, '2020-01-01', 3304557, 1, 1, 1, 1, 1,
+                     1, 1, 1, 1, 1, 1),
+                    (202403, '2024-01-15', 3304557, 30, 35, 9, 12.5, 1.5,
+                     21.1, 25.1, 31.1, 61.1, 70.1, 81.1),
+                    (202403, '2024-01-15', 3304557, 31, 36, 3, 13.5, 1.6,
+                     21.2, 25.2, 31.2, 61.2, 70.2, 81.2),
+                    (202700, '2027-01-01', 3304557, 100, 100, 1, 1, 1,
+                     1, 1, 1, 1, 1, 1)'''
+            )
+        )
+
+    with DB_ENGINE.connect() as connection:
+        result = connection.execute(
+            text(
+                f'''SELECT
+                    "SE", casos AS "casos notif.", casos_est,
+                    p_inc100k AS "incidência",
+                    p_rt1 AS "pr(incid. subir)", tempmin AS "temp.min",
+                    tempmed AS "temp.med", tempmax AS "temp.max",
+                    umidmin AS "umid.min", umidmed AS "umid.med",
+                    umidmax AS "umid.max",
+                    CASE
+                        WHEN nivel = 1 THEN 'verde'
+                        WHEN nivel = 2 THEN 'amarelo'
+                        WHEN nivel = 3 THEN 'laranja'
+                        WHEN nivel = 4 THEN 'vermelho'
+                        ELSE '-'
+                    END AS nivel,
+                    nivel AS level_code
+                FROM "Municipio"."{table}"
+                WHERE "SE" BETWEEN :start_week AND :end_week
+                  AND municipio_geocodigo = :geocode
+                ORDER BY "SE"
+                LIMIT 200'''
+            ),
+            {"start_week": 202203, "end_week": 202403, "geocode": 3304557},
+        )
+        expected = pd.DataFrame(
+            result.fetchall(), columns=result.keys()
+        ).set_index("SE")
+
+    with CaptureQueriesContext(connections["dados"]) as dados_queries:
+        with CaptureQueriesContext(connections["default"]) as default_queries:
+            actual = ReportCity.read_disease_data(disease, 3304557, 202403)
+
+    assert actual.index.is_monotonic_increasing
+    assert expected.index.is_monotonic_increasing
+    assert actual.index.duplicated().any()
+    pd.testing.assert_frame_equal(
+        _sort_rows_within_week(actual),
+        _sort_rows_within_week(expected),
+        check_dtype=True,
+    )
+    assert len(dados_queries) == 1
+    assert len(default_queries) == 0
+    assert f'"Municipio"."{table}"' in dados_queries[0]["sql"]
+
+
+def _sort_rows_within_week(data: pd.DataFrame) -> pd.DataFrame:
+    """Normalize only order that the legacy ``ORDER BY SE`` leaves open."""
+    return (
+        data.reset_index()
+        .sort_values(
+            by=["SE", *data.columns], kind="stable", na_position="last"
+        )
+        .reset_index(drop=True)
+    )

--- a/docs/database/orm_unmanaged_models.md
+++ b/docs/database/orm_unmanaged_models.md
@@ -61,6 +61,12 @@ The three Municipio.Historico_alerta tables have normalized unmanaged adapters.
 They remain separate physical tables; no merge or physical ownership change is
 implied. The historical-alert service is their canonical application boundary.
 
+`ReportCity.read_disease_data` now uses that service for its bounded,
+municipality-and-epidemiological-week city-report projection. It explicitly
+uses the `dados` alias and retains the legacy 200-row limit and output
+DataFrame contract. State reports, dashboard aggregates, compatibility APIs,
+exports, and alert-generation SQL remain intentional SQL boundaries.
+
 The public /api/v1/alert-city/ endpoint now uses that service and preserves its
 normalized response contract. The legacy /api/alertcity/ endpoint remains an
 explicit SQL compatibility path and is not a target of this sequence.


### PR DESCRIPTION
## Description

Migrate the bounded historical-alert query used by `ReportCity.read_disease_data` from raw SQL to the existing unmanaged Django ORM adapters.

The new service supports:

* dengue;
* chikungunya;
* Zika;
* municipality and epidemiological-week filtering;
* ascending week ordering;
* the existing 200-row limit;
* explicit routing through the `dados` database.

The existing DataFrame contract is preserved, including column names, index, value types, null handling and alert-level labels.

### Legacy SQL and ORM compatibility

The PostgreSQL-backed compatibility tests execute both approaches against the same fixture data:

1. The legacy SQL query reads directly from the corresponding `Municipio.Historico_alerta*` table.
2. The new ORM service executes the equivalent bounded query through the unmanaged model.
3. The resulting DataFrames are compared for:

   * columns and index;
   * complete values and data types;
   * municipality and inclusive week bounds;
   * null handling;
   * alert-level mapping;
   * duplicate epidemiological weeks.

Rows sharing the same week are normalized only within their equal-week group before comparison because the legacy query orders only by `SE`. No new production tie-breaker was introduced.

The tests also confirm that each ORM query:

* selects the correct disease-specific table;
* uses the `dados` alias;
* executes as a single database query;
* does not query historical-alert records through `default`;
* keeps filtering, ordering and the 200-row limit in PostgreSQL.

### Query-plan verification

A local PostgreSQL `EXPLAIN ANALYZE` comparison showed equivalent plans for the bounded dengue query:

* same physical table;
* same municipality and inclusive week predicates;
* same `alertas_unicos` index;
* no additional sort node;
* same `LIMIT 200`;
* same 105 returned rows.

The measured execution times were affected by cold and warm caches, so they are not presented as a direct performance comparison. The relevant result is plan equivalence.

### Out of scope

The following paths remain on SQL:

* compatibility APIs;
* state reports and dashboard aggregations;
* exports;
* analytical and window queries;
* alert generation and tasks.

No database migration or physical schema change is introduced.

### Validation

Existing test-database teardown and dependency deprecation warnings remain unchanged.

Closes #1088
