### PR TITLE
refactor(database): drop archived tweet columns

### DIFF
--- a/AlertaDengue/dados/migrations/0008_remove_historical_alert_tweet_column.py
+++ b/AlertaDengue/dados/migrations/0008_remove_historical_alert_tweet_column.py
@@ -1,0 +1,27 @@
+"""Remove the obsolete tweet values from historical-alert tables."""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop a retired AlertTools output from each disease history table."""
+
+    atomic = True
+
+    dependencies = [
+        ("dados", "0007_retained_referenced_adapters"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE "Municipio"."Historico_alerta"
+                DROP COLUMN "tweet";
+                ALTER TABLE "Municipio"."Historico_alerta_chik"
+                DROP COLUMN "tweet";
+                ALTER TABLE "Municipio"."Historico_alerta_zika"
+                DROP COLUMN "tweet";
+            """,
+            reverse_sql=None,
+        ),
+    ]

--- a/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
+++ b/AlertaDengue/tests/api/test_public_rest_v1_legacy_migration.py
@@ -205,6 +205,44 @@ def test_public_alert_city_route_reads_inserted_orm_record(
     assert response.json()["data"][0]["municipality_geocode"] == 3304557
 
 
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+@pytest.mark.parametrize(
+    ("disease", "model"),
+    [
+        ("dengue", LegacyHistoricalAlertDengue),
+        ("chikungunya", LegacyHistoricalAlertChikungunya),
+        ("zika", LegacyHistoricalAlertZika),
+    ],
+)
+def test_legacy_alert_city_route_works_without_tweet_column(
+    public_historical_alert_tables, disease, model
+):
+    """The broad legacy table read naturally omits the removed field."""
+    model.objects.create(
+        epidemiological_week_start_date=date(2026, 1, 4),
+        epidemiological_week=202601,
+        municipality_geocode=3304557,
+    )
+
+    response = APIClient().get(
+        reverse("api:alertcity"),
+        {
+            "disease": disease,
+            "geocode": 3304557,
+            "format": "json",
+            "ew_start": 1,
+            "ew_end": 52,
+            "ey_start": 2026,
+            "ey_end": 2026,
+        },
+    )
+
+    assert response.status_code == 200
+    record = response.json()[0]
+    assert record["SE"] == 202601
+    assert "tweet" not in record
+
+
 def test_v1_and_legacy_routes_resolve():
     assert reverse("api:v1:alert_city") == "/api/v1/alert-city/"
     assert reverse("api:v1:epi_year_week") == "/api/v1/epi-year-week/"

--- a/AlertaDengue/tests/dados/test_remove_historical_alert_tweet_migration.py
+++ b/AlertaDengue/tests/dados/test_remove_historical_alert_tweet_migration.py
@@ -1,0 +1,138 @@
+"""PostgreSQL regression coverage for historical-alert tweet removal."""
+
+from importlib import import_module
+
+from django.db import ProgrammingError, connections, transaction
+from django.db.migrations.state import ProjectState
+import pytest
+
+from manager.router import DatabaseAppsRouter
+
+TABLES = (
+    '"Municipio"."Historico_alerta"',
+    '"Municipio"."Historico_alerta_chik"',
+    '"Municipio"."Historico_alerta_zika"',
+)
+MIGRATION = import_module(
+    "dados.migrations.0008_remove_historical_alert_tweet_column"
+)
+
+
+def apply_migration_operation(connection):
+    """Run the actual Django migration operation on the ``dados`` alias."""
+    operation = MIGRATION.Migration.operations[0]
+    state = ProjectState()
+
+    assert connection.alias == "dados"
+    with connection.schema_editor() as schema_editor:
+        operation.database_forwards(
+            "dados", schema_editor, state, state.clone()
+        )
+
+
+@pytest.fixture
+def disposable_historical_alert_tables():
+    """Create only the disposable legacy tables required by this migration."""
+    connection = connections["dados"]
+    if connection.vendor != "postgresql":
+        pytest.skip("the migration is PostgreSQL-specific")
+
+    with connection.cursor() as cursor:
+        cursor.execute('CREATE SCHEMA IF NOT EXISTS "Municipio"')
+        for table in TABLES:
+            cursor.execute(f"DROP TABLE IF EXISTS {table}")
+            cursor.execute(
+                f"CREATE TABLE {table} ("
+                "id integer PRIMARY KEY, preserved_value text NOT NULL, "
+                '"tweet" numeric NULL DEFAULT NULL)'
+            )
+            cursor.execute(
+                f'INSERT INTO {table} (id, preserved_value, "tweet") '
+                "VALUES (1, 'retained', 1), (2, 'also-retained', NULL)"
+            )
+        cursor.execute(
+            'CREATE TABLE "Municipio"."tweet_migration_sentinel" '
+            "(id integer PRIMARY KEY, value text NOT NULL)"
+        )
+        cursor.execute(
+            'INSERT INTO "Municipio"."tweet_migration_sentinel" '
+            "VALUES (1, 'unchanged')"
+        )
+
+    yield connection
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            'DROP TABLE IF EXISTS "Municipio"."tweet_migration_sentinel"'
+        )
+        for table in TABLES:
+            cursor.execute(f"DROP TABLE IF EXISTS {table}")
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_tweet_removal_migration_preserves_historical_alert_rows_and_columns(
+    disposable_historical_alert_tables,
+):
+    """Apply the real migration SQL to disposable PostgreSQL tables."""
+    connection = disposable_historical_alert_tables
+
+    apply_migration_operation(connection)
+    with connection.cursor() as cursor:
+        for table in TABLES:
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'Municipio' AND table_name = %s "
+                "ORDER BY ordinal_position",
+                [table.split('"')[3]],
+            )
+            assert [row[0] for row in cursor.fetchall()] == [
+                "id",
+                "preserved_value",
+            ]
+            cursor.execute(
+                f"SELECT id, preserved_value FROM {table} ORDER BY id"
+            )
+            assert cursor.fetchall() == [
+                (1, "retained"),
+                (2, "also-retained"),
+            ]
+        cursor.execute(
+            'SELECT id, value FROM "Municipio"."tweet_migration_sentinel"'
+        )
+        assert cursor.fetchall() == [(1, "unchanged")]
+
+
+@pytest.mark.django_db(databases={"default", "dados"}, transaction=True)
+def test_tweet_removal_migration_is_atomic(disposable_historical_alert_tables):
+    """A failed statement rolls back all three column removals."""
+    connection = disposable_historical_alert_tables
+
+    with pytest.raises(ProgrammingError), transaction.atomic(using="dados"):
+        apply_migration_operation(connection)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'ALTER TABLE "Municipio"."missing" DROP COLUMN "tweet";'
+            )
+
+    with connection.cursor() as cursor:
+        for table in TABLES:
+            cursor.execute(
+                "SELECT count(*) FROM information_schema.columns "
+                "WHERE table_schema = 'Municipio' AND table_name = %s "
+                "AND column_name = 'tweet'",
+                [table.split('"')[3]],
+            )
+            assert cursor.fetchone() == (1,)
+
+
+def test_historical_alert_migration_is_routed_only_to_dados():
+    """Django's router prevents this ``dados`` migration on ``default``."""
+    router = DatabaseAppsRouter()
+
+    assert router.allow_migrate("dados", "dados") is True
+    assert router.allow_migrate("default", "dados") is False
+
+
+def test_tweet_removal_migration_is_explicitly_irreversible():
+    """The retired historical tweet values cannot be reconstructed."""
+    assert MIGRATION.Migration.operations[0].reverse_sql is None

--- a/docs/database/historical-alert-tweet-removal-runbook.md
+++ b/docs/database/historical-alert-tweet-removal-runbook.md
@@ -1,0 +1,92 @@
+# Historical-alert `tweet` removal runbook
+
+Migration `dados.0008_remove_historical_alert_tweet_column` removes the
+retired nullable numeric `tweet` column from the three historical-alert tables.
+It is atomic and irreversible. It does not use `CASCADE`, refresh materialized
+views, or change Django model state.
+
+## Before staging
+
+1. Confirm the deployed AlertTools build is revision
+   `9199ac34e066a5617985ce5b73003b47056bcd6d` and that its
+   `tabela_historico()` and `write_alerta()` implementations do not emit or
+   reference the historical-alert `tweet` field.
+2. Verify the archived Tweet data exists and is recoverable. Record the archive
+   identifier or path, creation date, archive verification result, and
+   responsible operator. Do not record credentials in this runbook or ticket.
+3. Verify a current, tested, restorable PostgreSQL backup. Record the backup
+   ID, timestamp, successful restore-check result, and responsible operator.
+4. Immediately before migration, query and record total, non-null, and NULL
+   `tweet` counts for every target table. The local audit baseline is:
+
+   | Table | Total | Non-null | NULL |
+   | --- | ---: | ---: | ---: |
+   | `Historico_alerta` | 4,823,903 | 3,909,767 | 914,136 |
+   | `Historico_alerta_chik` | 4,823,913 | 3,910,577 | 913,336 |
+   | `Historico_alerta_zika` | 4,099,637 | 4,099,637 | 0 |
+
+   Staging and production must be queried again immediately before migration;
+   do not assume these local values apply there.
+5. Check there are no long-running transactions or conflicting table locks:
+
+   ```sql
+   SELECT pid, usename, state, query_start, wait_event_type, wait_event,
+          query
+   FROM pg_stat_activity
+   WHERE datname = current_database()
+     AND state <> 'idle'
+   ORDER BY query_start;
+
+   SELECT relation::regclass, mode, granted, pid
+   FROM pg_locks
+   WHERE relation IN (
+       '"Municipio"."Historico_alerta"'::regclass,
+       '"Municipio"."Historico_alerta_chik"'::regclass,
+       '"Municipio"."Historico_alerta_zika"'::regclass
+   )
+   ORDER BY relation, granted DESC, mode;
+   ```
+
+6. Confirm the pre-flight schema: each table has a nullable `numeric` `tweet`
+   column with default `NULL`, and re-run the dependency audit for views,
+   materialized views, functions, triggers, constraints, and indexes.
+
+## Apply in staging
+
+1. Put writers that could use an older AlertTools build into maintenance mode.
+2. The normal `makim django.migrate` task runs `python manage.py migrate
+   --no-input` without `--database`; it targets `default`. The database router
+   rejects the `dados` app on `default`, so do not use that task for this
+   migration. Run the following explicit `dados` commands instead:
+
+   ```bash
+   python AlertaDengue/manage.py showmigrations dados --database=dados
+
+   python AlertaDengue/manage.py migrate \
+     dados 0008_remove_historical_alert_tweet_column \
+     --plan \
+     --database=dados
+
+   python AlertaDengue/manage.py migrate \
+     dados 0008_remove_historical_alert_tweet_column \
+     --database=dados
+   ```
+
+3. Review that the plan contains only `dados.0008`. Do not add `CASCADE`,
+   `IF EXISTS`, manual DDL, or a materialized-view refresh.
+4. Record the migration output and elapsed time. A lock timeout means stop and
+   resolve the conflicting session; do not retry against an unknown writer.
+
+## Verify
+
+1. Check all three tables no longer have `tweet` and that their row counts are
+   unchanged from the pre-flight record.
+2. Query `/api/alertcity/` for dengue, chikungunya, and Zika: each response must
+   be HTTP 200, retain its normal fields, and omit `tweet`.
+3. Smoke-test `/api/v1/alert-city/` and `/api/internal/historical-alerts/` to
+   confirm their existing response contracts remain unchanged.
+4. Inspect application, Celery, and PostgreSQL logs for missing-column or
+   writer errors.
+
+Recovery is a database restore from the verified pre-flight backup; the Django
+migration intentionally has no reverse operation.


### PR DESCRIPTION
## Description
- Remove the archived historical-alert `tweet` columns through an atomic, irreversible `dados` migration.
- Cover Django migration forwarding on the `dados` alias, rollback behavior, and legacy alert-city responses for all three diseases.
- Document archive/backup pre-flight, explicit alias migration commands, and post-migration verification.

Closes #1072