### PR TITLE
fix(dados): cap /report/ page cache at one hour

### DIFF
--- a/AlertaDengue/dados/urls.py
+++ b/AlertaDengue/dados/urls.py
@@ -152,7 +152,7 @@ urlpatterns = [
     ),
     re_path(
         r"^report/$",
-        cache_page(60 * 60 * 60 * 24)(ReportView.as_view()),
+        cache_page(60 * 60)(ReportView.as_view()),
         name="report",
     ),
     re_path(


### PR DESCRIPTION
## What

`/report/` was decorated with `cache_page(60 * 60 * 60 * 24)` = 5,184,000 s (~60 days), so the page kept serving stale HTML for ~two months after each deployment (#978).

## Change

Use `cache_page(60 * 60)` (one hour) for the `report` route — the same value the neighbouring `report_city` and `report_state` routes already use — so a deployment is reflected within an hour instead of two months.

Closes #978.
