### PR TITLE
docs(database): complete supporting schema ORM audit

### DIFF
--- a/AlertaDengue/tests/dados/test_supporting_schema_audit_contract.py
+++ b/AlertaDengue/tests/dados/test_supporting_schema_audit_contract.py
@@ -1,0 +1,37 @@
+"""Stable ORM contracts for the supporting-schema audit."""
+
+import pytest
+
+from dados.models import EpiscannerSirParams
+from manager.router import DatabaseAppsRouter
+
+
+def test_episcanner_adapter_contract() -> None:
+    """The existing EpiScanner table remains a managed dados adapter."""
+    assert EpiscannerSirParams._meta.db_table == '"episcanner"."sir_params"'
+    assert EpiscannerSirParams._meta.managed is True
+    assert EpiscannerSirParams._meta.get_field("id").primary_key
+    assert EpiscannerSirParams._meta.get_field("geocode").column == "geocode"
+    assert {
+        tuple(c.fields) for c in EpiscannerSirParams._meta.constraints
+    } == {("cid10", "geocode", "year")}
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_episcanner_routes_through_dados(operation: str) -> None:
+    """The repository router selects the dados alias for this model."""
+    router = DatabaseAppsRouter()
+    route = (
+        router.db_for_read(EpiscannerSirParams)
+        if operation == "read"
+        else router.db_for_write(EpiscannerSirParams)
+    )
+    assert route == "dados"
+
+
+def test_weather_and_vegetation_have_no_django_adapters() -> None:
+    """Supporting relations remain outside the ORM boundary."""
+    from dados import models
+
+    assert not hasattr(models, "Weather")
+    assert not hasattr(models, "VegetationIndexMetrics")

--- a/docs/database/orm_unmanaged_models.md
+++ b/docs/database/orm_unmanaged_models.md
@@ -8,6 +8,10 @@ quoted identifiers remain only in db_table and db_column mappings.
 The complete `Municipio` physical-schema and raw-SQL reconciliation is
 maintained in [`municipio_orm_coverage.md`](municipio_orm_coverage.md).
 
+The supporting-schema audit for `episcanner`, `vegetation_indices`, and
+`weather` is maintained in
+[`supporting_schemas_orm_coverage.md`](supporting_schemas_orm_coverage.md).
+
 ## Retained schema overview
 
 | Schema | Responsibility | Ownership | Refactor status |
@@ -16,7 +20,28 @@ maintained in [`municipio_orm_coverage.md`](municipio_orm_coverage.md).
 | Municipio | Historical alerts and notifications | Alerts external; notifications application-written through ingestion | Historical API complete |
 | ingestion | SINAN run, stage and rollback control | Django-managed | Current model boundary retained |
 | episcanner | Scan-result parameters | Django-managed | Current model boundary retained |
+| vegetation_indices | Geographic/time-series vegetation metrics | External analytical/ingestion ownership unresolved | Retain SQL boundary; no confirmed bounded ORM candidate |
+| weather | External geographic/time-series weather data | External analytical ownership unresolved | Retain SQL boundary; no confirmed bounded ORM candidate |
 | public | Derived report/dashboard materialized views | External/operational ownership unresolved | Retain SQL boundary |
+
+The supporting-schema audit found no additional confirmed bounded ORM read.
+`episcanner.sir_params` remains the existing managed ORM boundary; weather
+time-series and vegetation/analytics paths remain SQL or external boundaries.
+
+The public row above is intentionally selective and is not a result of the
+supporting-schema audit. The Municipio audit separately catalog-confirmed ten
+downstream public materialized-view dependencies:
+
+- `city_count_by_uf_dengue_materialized_view`
+- `hist_uf_dengue_materialized_view`
+- `uf_total_view`
+- `city_count_by_uf_chikungunya_materialized_view`
+- `hist_uf_chik_materialized_view`
+- `uf_total_chik_view`
+- `city_count_by_uf_zika_materialized_view`
+- `hist_uf_zika_materialized_view`
+- `uf_total_zika_view`
+- `epiyear_summary_materialized_view`
 
 ## Retained object inventory
 
@@ -86,7 +111,8 @@ historical-alert, city-report, map-scalar, and internal-notification paths are
 covered; compatibility, analytical, bulk, transactional, and geofile SQL
 boundaries are deliberate. See the [Municipio audit](municipio_orm_coverage.md)
 for the physical `0008` migration-state/schema discrepancy and external writer
-follow-ups.
+follow-ups. Across the retained schema groups, no additional ORM refactor is
+currently justified.
 
 ## Explicit SQL boundaries
 

--- a/docs/database/supporting_schemas_orm_coverage.md
+++ b/docs/database/supporting_schemas_orm_coverage.md
@@ -1,0 +1,123 @@
+# Supporting schemas ORM coverage
+
+Audit date: 2026-09-08
+
+## Scope and evidence
+
+This audit covers `episcanner`, `vegetation_indices`, and `weather`. It
+excludes DDL, migrations, data writes, model changes, and speculative adapters. Searches covered Django runtime code, tasks, services,
+SQL helpers, SQL history, scripts, tests, documentation, settings, and the database router.
+
+Catalog-confirmed facts below were obtained through the repository's read-only
+database verification path. No exact `COUNT(*)` was run for large weather
+tables; approximate row counts use PostgreSQL catalog estimates and relation
+sizes use `pg_total_relation_size`. Repository-search findings and unresolved
+operational ownership are identified separately.
+
+## Catalog-confirmed facts
+
+## Relation inventory
+
+| Schema | Relation | Kind | Rows / size | Identity | Django model |
+| --- | --- | --- | --- | --- | --- |
+| `episcanner` | `sir_params` | table | 32,770 / 6,905,856 bytes | `id` PK; unique `(cid10, geocode, year)` | `dados.models.EpiscannerSirParams` |
+| `episcanner` | `sir_params_id_seq` | sequence | 8,192 bytes | sequence for `sir_params.id` | none |
+| `vegetation_indices` | `vegetation_index_metrics` | table | 3,297,440 / 535,633,920 bytes | PK `(date, geocode, collection, attribute)` | none |
+| `weather` | `copernicus_bra` | table | 54,191,956 / 10,249,068,544 bytes | unique `(date, geocode)`; no PK | none |
+| `weather` | `copernicus_bra_precip_tot_fixed` | table | 54,451,104 / 7,638,327,296 bytes | unique `(date, geocode)`; no PK | none |
+
+The verified catalog inventory contains 4 ordinary tables, 1 sequence, and 9
+indexes across the three schemas; no partitioned table, view, materialized
+view, or foreign table was found. All verified relations are owned by the
+catalog owner, have no table comments, no user-defined triggers, and no
+dependent views, materialized views, or functions. Weather relations remain
+part of the operational weather lifecycle; this reference does not prescribe
+archival or retention changes.
+
+Live columns: `sir_params` has `id integer NOT NULL` (identity `d`), `cid10
+varchar(10) NOT NULL`, `year integer NOT NULL`, `ep_ini varchar(20) NULL`,
+`ep_pw varchar(20) NOT NULL`, `ep_end varchar(20) NULL`, `ep_dur integer NULL`,
+`peak_week`, `beta`, `gamma`, `r0`, `total_cases`, `alpha`, and `sum_res` all
+`double precision NOT NULL`, `t_ini integer NULL`, `t_end integer NULL`, and
+`geocode integer NOT NULL`. `vegetation_index_metrics` has `date date NOT
+NULL`, `geocode integer NOT NULL`, `collection varchar(255) NOT NULL`,
+`attribute varchar(50) NOT NULL`, and nullable `double precision` columns
+`mean`, `std`, `median`, `q25`, `q75`, `min`, and `max`.
+
+`copernicus_bra` has `date timestamp without time zone NOT NULL`, `geocode
+integer NOT NULL`, `temp_max`, `precip_max`, `umid_max`, `pressao_max`, `temp_med`,
+`precip_med`, `umid_med`, `pressao_med`, `temp_min`, `precip_min`, `umid_min`,
+`pressao_min`, and `precip_tot` as `double precision NOT NULL`, plus `epiweek
+integer NOT NULL`. The additional table has `date date NOT NULL`, `geocode text
+NOT NULL`, and nullable `double precision` columns `precip_tot`, `precip_min`,
+`precip_med`, and `precip_max`.
+
+Catalog-confirmed index names are `sir_params_geocode_e198a8ac`,
+`sir_params_pkey`, `uq_sir_params_cid10_geocode_year`,
+`vegetation_index_metrics_pkey`, `copernicus_bra_unique_date_geocode`,
+`copernicus_bra_precip_tot_fixed_date_geocode_key`,
+`idx_copernicus_bra_precip_tot_fixed_date`,
+`idx_copernicus_bra_precip_tot_fixed_date_geocode`, and
+`idx_copernicus_bra_precip_tot_fixed_geocode`. EpiScanner also has the catalog-confirmed foreign key to `Dengue_global.Municipio(geocodigo)`.
+
+## Repository-search findings
+
+## Model coverage and routing
+
+`EpiscannerSirParams` maps to `"episcanner"."sir_params"`, is managed, uses
+the physical `id` primary key, and declares `(cid10, geocode, year)` unique.
+`dados.tasks._save_sir_params` writes with `update_or_create()`. The router
+maps both reads and writes for app `dados` to alias `dados`. `managed=True`
+controls Django lifecycle management; routing is not write prevention.
+
+There are no adapters for the vegetation or weather relations. No arbitrary
+primary key, implicit `id`, or synthetic composite identity is proposed.
+
+## Readers, writers, and ownership
+
+The active EpiScanner flow is `episcanner_all_states` →
+`episcanner_scan_state` → `_fetch_alert_data` (SQLAlchemy/DataFrame read from
+historical alert tables) → EpiScanner calculation → `_save_sir_params` (ORM
+write). The source read is a state/year window but has an analytical
+DataFrame contract; persistence is already ORM-backed.
+
+No vegetation reader or writer was found in this checkout. That means no
+repository writer was found, not that no external writer exists. Ownership is
+unresolved between analytics, ingestion, and external operation.
+
+Weather relations contain external geographic/time-series data. Repository
+evidence includes an R helper with a weather time-series read, while no active
+Django runtime reader or writer was found. Consumers may be analytical,
+ingestion, operational, or archival workflows; external writer, retention,
+date-range, and column contracts need owner confirmation.
+
+| Schema | Read path | Write path | Classification |
+| --- | --- | --- | --- |
+| `episcanner` | ORM result access; analytical SQL input remains SQL/DataFrame | `_save_sir_params` ORM upsert | already ORM-backed / analytical boundary |
+| `vegetation_indices` | none found in repository | none found in repository | unresolved external/analytics/ingestion |
+| `weather` | external/R time-series reads | none found in repository | retained SQL/external boundary |
+
+## Operational boundary assumptions
+
+The catalog snapshot describes physical relations at verification time.
+External analytical, ingestion, operational, and archival owners may maintain
+relations or consumers outside this repository.
+
+## ORM decision
+
+No safe bounded ORM candidate was confirmed. Weather paths are large
+time-series/DataFrame reads and lack confirmed Django identity. Vegetation
+usage and identity are unresolved. EpiScanner persistence already uses ORM.
+Retain SQL for time-series, analytics, DataFrame shaping, external consumers,
+ingestion, bulk operations, and database-specific or spatial behavior.
+
+No separate implementation issue should be created for a speculative model. No
+additional ORM refactor is currently justified.
+
+## Follow-up questions
+
+1. Preserve this catalog snapshot as verification evidence; repeat the
+   read-only probe only when the physical database changes.
+2. Confirm owner/writer/lifecycle for vegetation and all weather relations.
+3. Reassess only if an enforced-identity, active bounded metadata lookup is
+   found; large weather and analytical paths remain SQL.


### PR DESCRIPTION
## Description

Completes the ORM coverage audit for the remaining supporting database
schemas and consolidates the maintained ORM boundaries.

### Findings

- All proposed application schema groups are accounted for.
- Appropriate bounded reads in `Dengue_global` and `Municipio` are ORM-backed.
- The `ingestion` tables use managed Django models.
- `episcanner.sir_params` is already ORM-backed.
- No confirmed active bounded ORM candidate remains for `vegetation_indices`
  or `weather`.
- Public views and materialized views remain intentional SQL boundaries.
- Remaining SQL supports compatibility, analytics, DataFrames, time-series
  processing, bulk ingestion, UPSERTs, rollback, PostGIS/geofile,
  materialized-view, and archival workflows.
- No additional ORM implementation issue is recommended.

### Changes

- Adds the supporting-schema ORM coverage reference.
- Updates the maintained unmanaged-model and SQL-boundary documentation.
- Adds focused audit-contract tests.

### Scope

This PR does not change:

- production Django models;
- application SQL;
- database migrations;
- physical schemas;
- materialized views;
- ingestion or archival workflows.

### Validation

- Focused audit-contract tests: `4 passed`
- Complete unit suite: `505 passed, 6 warnings in 61.34s`
- `makemigrations --check --dry-run`: no changes detected
- Pre-commit: all hooks passed
- `git diff --check`: passed

- Closes #1118 
This audit concludes the current ORM migration initiative.