### PR TITLE
fix(database): restore PostgreSQL image builds on Bookworm

### DIFF
--- a/containers/pgbackrest/Dockerfile
+++ b/containers/pgbackrest/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 ARG HOST_UID
 ARG HOST_GID

--- a/containers/postgres/Dockerfile
+++ b/containers/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # from https://github.com/postgis/docker-postgis/blob/969ef8a9e4a22e1556ca99cab4178f6e60c1483d/14-3.2/Dockerfile
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 LABEL maintainer="Sandro Loch <es.loch@gmail.com>"
 
@@ -18,6 +18,7 @@ RUN usermod -u ${HOST_UID} postgres \
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+      python3 \
       postgresql-plpython3-14 \
       postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \


### PR DESCRIPTION
## Description

Moves the PostgreSQL and pgBackRest container images from Debian Bullseye to
Bookworm while retaining PostgreSQL 14.

This restores CI builds affected by the expired Bullseye security repository
metadata without introducing a PostgreSQL major-version upgrade.

### Changes

- Updates `containers/postgres/Dockerfile` from
  `postgres:14-bullseye` to `postgres:14-bookworm`.
- Updates `containers/pgbackrest/Dockerfile` from
  `postgres:14-bullseye` to `postgres:14-bookworm`.
- Installs the Python runtime required by PostgreSQL PL/Python on Bookworm.
- Retains PostgreSQL 14, PostGIS 3, PL/Python and pgBackRest.

### Scope

This PR does not:

- upgrade PostgreSQL to a new major version;
- modify the PostgreSQL data-directory layout;
- change database schemas or migrations;
- modify backup or restore workflows;
- change application behavior.

The PostgreSQL 18 upgrade will be handled separately with backup, restore,
extension compatibility, staging and rollback validation.

### Validation

- Both PostgreSQL-related images build successfully.
- PostgreSQL starts and accepts connections.
- PostGIS and `plpython3u` extensions are available.
- pgBackRest starts with the existing configuration.
- CI database tests pass.

Closes #1119